### PR TITLE
Add build step to publish step in Github actions workflow

### DIFF
--- a/.github/workflows/build_test_publish.yaml
+++ b/.github/workflows/build_test_publish.yaml
@@ -46,6 +46,7 @@ jobs:
             exit 1
           fi
       - run: npm ci
+      - run: npm run build
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hasura/ndc-sdk-typescript",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Missing build step meant that published NPM packages didn't have access to built package.