### PR TITLE
Update SDK to match Rust SDK v0.1.0-rc.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "ndc-client"
 version = "0.1.0"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.11#3ef71ffecbba088ebb5f452114b2dc662f1b9d3f"
+source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.13#1f9b2a996ad74ac4bc97a783c4d014a3fd46b08e"
 dependencies = [
  "async-trait",
  "indexmap 2.1.0",

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.2.8
+- Add new `ConnectorError` types:
+  - `UnprocessableContent`: The request could not be handled because, while the request was well-formed, it was not semantically correct. For example, a value for a custom scalar type was provided, but with an incorrect type
+  - `BadGateway`: The request could not be handled because an upstream service was unavailable or returned an unexpected response, e.g., a connection to a database server failed
+- Generate TypeScript declaration maps for better "go to definition" tooling
+
 ## 1.2.7
 
 - `get_serve_command` and `get_serve_configuration_command` now support creation without

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hasura/ndc-sdk-typescript",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hasura/ndc-sdk-typescript",
-      "version": "1.2.7",
+      "version": "1.2.8",
       "license": "ISC",
       "dependencies": {
         "@json-schema-tools/meta-schema": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hasura/ndc-sdk-typescript",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/error.ts
+++ b/src/error.ts
@@ -5,8 +5,10 @@ type ErrorCode =
   | /** Bad Request - The request did not match the data connector's expectation based on this specification. */ 400
   | /** Forbidden - The request could not be handled because a permission check failed - for example, a mutation might fail because a check constraint was not met.*/ 403
   | /** Conflict - The request could not be handled because it would create a conflicting state for the data source - for example, a mutation might fail because a foreign key constraint was not met.*/ 409
+  | /** Unprocessable Content - The request could not be handled because, while the request was well-formed, it was not semantically correct. For example, a value for a custom scalar type was provided, but with an incorrect type.*/ 422
   | /** Internal Server Error - The request could not be handled because of an error on the server */ 500
-  | /** Not Supported - The request could not be handled because it relies on an unsupported capability. Note: this ought to indicate an error on the caller side, since the caller should not generate requests which are incompatible with the indicated capabilities. */ 501;
+  | /** Not Supported - The request could not be handled because it relies on an unsupported capability. Note: this ought to indicate an error on the caller side, since the caller should not generate requests which are incompatible with the indicated capabilities. */ 501
+  | /** Bad Gateway - The request could not be handled because an upstream service was unavailable or returned an unexpected response, e.g., a connection to a database server failed. */ 502;
 
 export class ConnectorError extends Error {
   statusCode: ErrorCode;
@@ -58,6 +60,17 @@ export class Conflict extends ConnectorError {
     super(409, message, details);
   }
 }
+
+/** The request could not be handled because, while the request was well-formed, it was not semantically correct. For example, a value for a custom scalar type was provided, but with an incorrect type */
+export class UnprocessableContent extends ConnectorError {
+  constructor(
+    message: ErrorResponse["message"],
+    details?: ErrorResponse["details"]
+  ) {
+    super(422, message, details);
+  }
+}
+
 /** The request could not be handled because of an error on the server */
 export class InternalServerError extends ConnectorError {
   constructor(
@@ -67,6 +80,7 @@ export class InternalServerError extends ConnectorError {
     super(500, message, details);
   }
 }
+
 /** The request could not be handled because it relies on an unsupported capability. Note: this ought to indicate an error on the caller side, since the caller should not generate requests which are incompatible with the indicated capabilities */
 export class NotSupported extends ConnectorError {
   constructor(
@@ -74,5 +88,15 @@ export class NotSupported extends ConnectorError {
     details?: ErrorResponse["details"]
   ) {
     super(501, message, details);
+  }
+}
+
+/** The request could not be handled because an upstream service was unavailable or returned an unexpected response, e.g., a connection to a database server failed */
+export class BadGateway extends ConnectorError {
+  constructor(
+    message: ErrorResponse["message"],
+    details?: ErrorResponse["details"]
+  ) {
+    super(502, message, details);
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -50,7 +50,7 @@
 
     /* Emit */
     "declaration": true,                                 /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    "declarationMap": true,                              /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     "sourceMap": true,                                   /* Create source map files for emitted JavaScript files. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */

--- a/typegen/Cargo.toml
+++ b/typegen/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ndc-client = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.11" }
+ndc-client = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.13" }
 schemars = "0.8.15"
 serde = "^1.0"
 serde_json = "1.0.107"


### PR DESCRIPTION
Adds new `ConnectorError` types:
  - `UnprocessableContent`: The request could not be handled because, while the request was well-formed, it was not semantically correct. For example, a value for a custom scalar type was provided, but with an incorrect type
  - `BadGateway`: The request could not be handled because an upstream service was unavailable or returned an unexpected response, e.g., a connection to a database server failed

Also enables generation of TypeScript declaration maps for better "go to definition" tooling.