### PR TITLE
Support v0.1.0-rc.15 of the NDC spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "ndc-client"
 version = "0.1.0"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.14#cd24992ea77010e1ef2dff18f7d5656fb0546f3b"
+source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.0-rc.15#7e10c73d19d03627b96cc666eadcd35f784517e0"
 dependencies = [
  "async-trait",
  "indexmap 2.1.0",

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.0.0
+Breaking change: support for the [v0.1.0-rc.15 of NDC Spec](https://github.com/hasura/ndc-spec/compare/v0.1.0-rc.14...v0.1.0-rc.15).
+
+- The [mutation request/response format has changed](https://github.com/hasura/ndc-spec/pull/90).
+  - `MutationOperation` fields are now defined as a `NestedField`
+  - `MutationOperationResponse` now returns a single value rather than a rowset
+
 ## 2.0.0
 Breaking change: support for the [v0.1.0-rc.14 of NDC Spec](https://github.com/hasura/ndc-spec/compare/v0.1.0-rc.13...v0.1.0-rc.14).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "@hasura/ndc-sdk-typescript",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hasura/ndc-sdk-typescript",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "ISC",
       "dependencies": {
         "@json-schema-tools/meta-schema": "^1.7.0",
-        "@types/node": "^20.6.0",
         "commander": "^11.0.0",
         "fastify": "^4.23.2",
         "pino-pretty": "^10.2.3"
       },
       "devDependencies": {
+        "@types/node": "^20.6.0",
         "json-schema-to-typescript": "^13.1.1",
         "typescript": "^5.2.2"
       }
@@ -108,7 +108,8 @@
     "node_modules/@types/node": {
       "version": "20.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.0.tgz",
-      "integrity": "sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg=="
+      "integrity": "sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg==",
+      "dev": true
     },
     "node_modules/@types/prettier": {
       "version": "2.7.3",
@@ -1360,7 +1361,8 @@
     "@types/node": {
       "version": "20.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.0.tgz",
-      "integrity": "sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg=="
+      "integrity": "sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg==",
+      "dev": true
     },
     "@types/prettier": {
       "version": "2.7.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hasura/ndc-sdk-typescript",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -14,12 +14,12 @@
   "license": "ISC",
   "dependencies": {
     "@json-schema-tools/meta-schema": "^1.7.0",
-    "@types/node": "^20.6.0",
     "commander": "^11.0.0",
     "fastify": "^4.23.2",
     "pino-pretty": "^10.2.3"
   },
   "devDependencies": {
+    "@types/node": "^20.6.0",
     "json-schema-to-typescript": "^13.1.1",
     "typescript": "^5.2.2"
   }

--- a/src/schema/schema.generated.json
+++ b/src/schema/schema.generated.json
@@ -1654,14 +1654,15 @@
               "additionalProperties": true
             },
             "fields": {
-              "description": "The fields to return",
-              "type": [
-                "object",
-                "null"
-              ],
-              "additionalProperties": {
-                "$ref": "#/definitions/Field"
-              }
+              "description": "The fields to return from the result, or null to return everything",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/NestedField"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             }
           }
         }
@@ -1685,31 +1686,24 @@
     },
     "MutationOperationResults": {
       "title": "Mutation Operation Results",
-      "type": "object",
-      "required": [
-        "affected_rows"
-      ],
-      "properties": {
-        "affected_rows": {
-          "description": "The number of rows affected by the mutation operation",
-          "type": "integer",
-          "format": "uint32",
-          "minimum": 0.0
-        },
-        "returning": {
-          "description": "The rows affected by the mutation operation",
-          "type": [
-            "array",
-            "null"
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "result",
+            "type"
           ],
-          "items": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/definitions/RowFieldValue"
-            }
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "procedure"
+              ]
+            },
+            "result": true
           }
         }
-      }
+      ]
     },
     "ExplainResponse": {
       "title": "Explain Response",

--- a/src/schema/schema.generated.ts
+++ b/src/schema/schema.generated.ts
@@ -265,11 +265,13 @@ export type MutationOperation = {
     [k: string]: unknown;
   };
   /**
-   * The fields to return
+   * The fields to return from the result, or null to return everything
    */
-  fields?: {
-    [k: string]: Field;
-  } | null;
+  fields?: NestedField | null;
+};
+export type MutationOperationResults = {
+  type: "procedure";
+  result: unknown;
 };
 
 export interface SchemaRoot {
@@ -661,20 +663,6 @@ export interface MutationResponse {
    * The results of each mutation operation, in the same order as they were received
    */
   operation_results: MutationOperationResults[];
-}
-export interface MutationOperationResults {
-  /**
-   * The number of rows affected by the mutation operation
-   */
-  affected_rows: number;
-  /**
-   * The rows affected by the mutation operation
-   */
-  returning?:
-    | {
-        [k: string]: RowFieldValue;
-      }[]
-    | null;
 }
 export interface ExplainResponse {
   /**

--- a/typegen/Cargo.toml
+++ b/typegen/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ndc-client = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.14" }
+ndc-client = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.0-rc.15" }
 schemars = "0.8.15"
 serde = "^1.0"
 serde_json = "1.0.107"


### PR DESCRIPTION
Updates NDC SDK support version to v0.1.0-rc.15 of the NDC Spec. This involves another breaking change, so the package major version has been bumped again to v3.0.0.

See changelog changes for more information about what changed exactly.