### PR TITLE
update to include types

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@hasura/ndc-sdk-typescript",
   "version": "4.2.0",
   "description": "",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js",
     "./instrumentation": "./dist/instrumentation.js"


### PR DESCRIPTION
The types were removed with v4.0.1 here: https://github.com/hasura/ndc-sdk-typescript/commit/a4ce39d553e8a5cdd41d4b10818b039ded83bd4e

Specifically, notice the diff for the package.json, which removed types. This breaks trying to import things from the sdk. 
