### PR TITLE
Support b3 (zipkin) OpenTelemetry trace propagation headers

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -54,6 +54,10 @@ export function initTelemetry(
       new PinoInstrumentation({
         logHook: (span, record, level) => {
           record["resource.service.name"] = serviceName;
+          // This logs the parent span ID in the pino logs, useful for debugging propagation.
+          // parentSpanId is an internal property, hence the cast to any, because I can't
+          // seem to find a way to get at it through a supported API 😭
+          record["parent_span_id"] = (span as any).parentSpanId;
         },
       }),
     ],

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -7,6 +7,8 @@ import { FastifyInstrumentation } from "@opentelemetry/instrumentation-fastify";
 import { HttpInstrumentation } from "@opentelemetry/instrumentation-http";
 import { FetchInstrumentation } from "@opentelemetry/instrumentation-fetch";
 import { Attributes, Span, SpanStatusCode, Tracer } from "@opentelemetry/api";
+import { CompositePropagator, W3CBaggagePropagator, W3CTraceContextPropagator } from "@opentelemetry/core";
+import { B3Propagator, B3InjectEncoding } from "@opentelemetry/propagator-b3"
 
 let sdk: opentelemetry.NodeSDK | null = null;
 
@@ -55,6 +57,14 @@ export function initTelemetry(
         },
       }),
     ],
+    textMapPropagator: new CompositePropagator({
+      propagators: [
+        new W3CTraceContextPropagator(),
+        new W3CBaggagePropagator(),
+        new B3Propagator(),
+        new B3Propagator({ injectEncoding: B3InjectEncoding.MULTI_HEADER }),
+      ]
+    }),
   });
 
   process.on("beforeExit", async () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -176,7 +176,7 @@ export async function startServer<Configuration, State>(
         Body: QueryRequest;
       }>
     ) => {
-      request.log.debug({ requestBody: request.body }, "Query Request");
+      request.log.debug({ requestHeaders: request.headers, requestBody: request.body }, "Query Request");
 
       const queryResponse = await withActiveSpan(
         tracer,
@@ -201,7 +201,7 @@ export async function startServer<Configuration, State>(
       },
     },
     async (request: FastifyRequest<{ Body: QueryRequest }>) => {
-      request.log.debug({ requestBody: request.body }, "Explain Request");
+      request.log.debug({ requestHeaders: request.headers, requestBody: request.body }, "Explain Request");
 
       const explainResponse = await withActiveSpan(
         tracer,
@@ -233,7 +233,7 @@ export async function startServer<Configuration, State>(
         Body: MutationRequest;
       }>
     ): Promise<MutationResponse> => {
-      request.log.debug({ requestBody: request.body }, "Mutation Request");
+      request.log.debug({ requestHeaders: request.headers, requestBody: request.body }, "Mutation Request");
 
       const mutationResponse = await withActiveSpan(
         tracer,
@@ -262,7 +262,7 @@ export async function startServer<Configuration, State>(
     },
     async (request: FastifyRequest<{ Body: MutationRequest }>) => {
       request.log.debug(
-        { requestBody: request.body },
+        { requestHeaders: request.headers, requestBody: request.body },
         "Mutation Explain Request"
       );
 


### PR DESCRIPTION
This PR adds support for the b3 (zipkin) OpenTelemetry trace propagation headers. The [old default](https://github.com/open-telemetry/opentelemetry-js/blob/26101229aeb1eb8323e8afadd72c3bb1d50865c9/packages/opentelemetry-core/src/utils/environment.ts#L194C15-L194C49) was `tracecontext` and `baggage`, now we've extended that with `b3` and `b3-multi` by manually configuring the propagators in `instrumentation.ts`.

In addition:
* I've added the parent span id to the stdout logs (we already log the trace id and span id); this can help debug trace propagation issues in production
* I've added request headers to the debug-level tracing, which can also be useful in debugging trace propagation if all else fails. Debug logging is off by default.