### PR TITLE
NDC Spec v0.1.3 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 5.0.0
+- Updated to support [v0.1.3 of the NDC Spec](https://hasura.github.io/ndc-spec/specification/changelog.html#013) ([#32](https://github.com/hasura/ndc-sdk-typescript/pull/32))
+  - Breaking change: new `nested_fields` property on `QueryCapabilities`; set it to `{}` to retain previous v0.1.2 semantics and not support new v0.1.3 capabilities.
+  - Support [field arguments](https://hasura.github.io/ndc-spec/specification/queries/arguments.html#field-arguments)
+  - Support [filtering](https://hasura.github.io/ndc-spec/specification/queries/filtering.html#referencing-nested-fields-within-columns) and [ordering](https://hasura.github.io/ndc-spec/specification/queries/sorting.html#type-column) by nested fields
+  - Added a [`biginteger` type representation](https://hasura.github.io/ndc-spec/specification/schema/scalar-types.html#type-representations)
+
 ## 4.6.0
 - Use [`prom-client`](https://github.com/siimon/prom-client) to implement the metrics endpoint ([#29](https://github.com/hasura/ndc-sdk-typescript/pull/29))
 - Allow any error code in custom HTTP responses ([#30](https://github.com/hasura/ndc-sdk-typescript/pull/30))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,9 @@ checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bumpalo"
@@ -238,8 +238,8 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "ndc-models"
-version = "0.1.2"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.2#6e7d12a31787d5f618099a42ddc0bea786438c00"
+version = "0.1.3"
+source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.3#b9316d206a6aece470531937f6e1ea9223e88122"
 dependencies = [
  "indexmap 2.2.6",
  "schemars",
@@ -371,15 +371,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "2.3.3"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
+checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
 dependencies = [
  "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
+ "indexmap 2.2.6",
  "serde",
+ "serde_derive",
  "serde_json",
  "serde_with_macros",
  "time",
@@ -387,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "2.3.3"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
+checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hasura/ndc-sdk-typescript",
-  "version": "4.6.0",
+  "version": "5.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hasura/ndc-sdk-typescript",
-      "version": "4.6.0",
+      "version": "5.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@json-schema-tools/meta-schema": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hasura/ndc-sdk-typescript",
-  "version": "4.6.0",
+  "version": "5.0.0",
   "description": "",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/schema/schema.generated.json
+++ b/src/schema/schema.generated.json
@@ -89,6 +89,9 @@
     "QueryCapabilities": {
       "title": "Query Capabilities",
       "type": "object",
+      "required": [
+        "nested_fields"
+      ],
       "properties": {
         "aggregates": {
           "description": "Does the connector support aggregate queries",
@@ -122,12 +125,48 @@
               "type": "null"
             }
           ]
+        },
+        "nested_fields": {
+          "description": "Does the connector support nested fields",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NestedFieldCapabilities"
+            }
+          ]
         }
       }
     },
     "LeafCapability": {
       "description": "A unit value to indicate a particular leaf capability is supported. This is an empty struct to allow for future sub-capabilities.",
       "type": "object"
+    },
+    "NestedFieldCapabilities": {
+      "title": "Nested Field Capabilities",
+      "type": "object",
+      "properties": {
+        "filter_by": {
+          "description": "Does the connector support filtering by values of nested fields",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "order_by": {
+          "description": "Does the connector support ordering by values of nested fields",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
     },
     "MutationCapabilities": {
       "title": "Mutation Capabilities",
@@ -421,6 +460,21 @@
               "type": "string",
               "enum": [
                 "float64"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Arbitrary-precision integer string",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "biginteger"
               ]
             }
           }
@@ -799,6 +853,37 @@
               "$ref": "#/definitions/Type"
             }
           ]
+        },
+        "arguments": {
+          "description": "The arguments available to the field - Matches implementation from CollectionInfo",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ArgumentInfo"
+          }
+        }
+      }
+    },
+    "ArgumentInfo": {
+      "title": "Argument Info",
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "description": {
+          "description": "Argument description",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "description": "The name of the type of this argument",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Type"
+            }
+          ]
         }
       }
     },
@@ -848,30 +933,6 @@
           "additionalProperties": {
             "$ref": "#/definitions/ForeignKeyConstraint"
           }
-        }
-      }
-    },
-    "ArgumentInfo": {
-      "title": "Argument Info",
-      "type": "object",
-      "required": [
-        "type"
-      ],
-      "properties": {
-        "description": {
-          "description": "Argument description",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "type": {
-          "description": "The name of the type of this argument",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Type"
-            }
-          ]
         }
       }
     },
@@ -1196,6 +1257,12 @@
                   "type": "null"
                 }
               ]
+            },
+            "arguments": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/Argument"
+              }
             }
           }
         },
@@ -1274,6 +1341,47 @@
             "fields": {
               "$ref": "#/definitions/NestedField"
             }
+          }
+        }
+      ]
+    },
+    "Argument": {
+      "title": "Argument",
+      "oneOf": [
+        {
+          "description": "The argument is provided by reference to a variable",
+          "type": "object",
+          "required": [
+            "name",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "variable"
+              ]
+            },
+            "name": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "The argument is provided as a literal value",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "literal"
+              ]
+            },
+            "value": true
           }
         }
       ]
@@ -1397,6 +1505,16 @@
             "name": {
               "description": "The name of the column",
               "type": "string"
+            },
+            "field_path": {
+              "description": "Path to a nested field within an object column",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
             },
             "path": {
               "description": "Any relationships to traverse to reach this column",
@@ -1657,6 +1775,16 @@
               "description": "The name of the column",
               "type": "string"
             },
+            "field_path": {
+              "description": "Path to a nested field within an object column",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
             "path": {
               "description": "Any relationships to traverse to reach this column",
               "type": "array",
@@ -1682,6 +1810,16 @@
             "name": {
               "description": "The name of the column",
               "type": "string"
+            },
+            "field_path": {
+              "description": "Path to a nested field within an object column",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
             }
           }
         }
@@ -1805,47 +1943,6 @@
                 "$ref": "#/definitions/RelationshipArgument"
               }
             }
-          }
-        }
-      ]
-    },
-    "Argument": {
-      "title": "Argument",
-      "oneOf": [
-        {
-          "description": "The argument is provided by reference to a variable",
-          "type": "object",
-          "required": [
-            "name",
-            "type"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "variable"
-              ]
-            },
-            "name": {
-              "type": "string"
-            }
-          }
-        },
-        {
-          "description": "The argument is provided as a literal value",
-          "type": "object",
-          "required": [
-            "type",
-            "value"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "literal"
-              ]
-            },
-            "value": true
           }
         }
       ]

--- a/typegen/Cargo.toml
+++ b/typegen/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.2" }
+ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.3" }
 schemars = "0.8.15"
 serde = "^1.0"
 serde_json = "1.0.107"


### PR DESCRIPTION
This PR adds support for [NDC Spec v0.1.3](https://hasura.github.io/ndc-spec/specification/changelog.html#013). Unfortunately this is a breaking change because specifying a new nested fields capability is required. However, it's trivial for connectors to add.

See changelog for more information.