### PR TITLE
Support for ndc-spec v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.1.0
+- Updated to support [v0.1.4 of the NDC Spec](https://hasura.github.io/ndc-spec/specification/changelog.html#014) ([#33](https://github.com/hasura/ndc-sdk-typescript/pull/33))
+  - Support for [aggregates](https://hasura.github.io/ndc-spec/specification/queries/aggregates.html) over nested fields
+
 ## 5.0.0
 - Updated to support [v0.1.3 of the NDC Spec](https://hasura.github.io/ndc-spec/specification/changelog.html#013) ([#32](https://github.com/hasura/ndc-sdk-typescript/pull/32))
   - Breaking change: new `nested_fields` property on `QueryCapabilities`; set it to `{}` to retain previous v0.1.2 semantics and not support new v0.1.3 capabilities.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,8 +238,8 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "ndc-models"
-version = "0.1.3"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.3#b9316d206a6aece470531937f6e1ea9223e88122"
+version = "0.1.4"
+source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.4#20172e3b2552b78d16dbafcd047f559ced420309"
 dependencies = [
  "indexmap 2.2.6",
  "schemars",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hasura/ndc-sdk-typescript",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hasura/ndc-sdk-typescript",
-      "version": "5.0.0",
+      "version": "5.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@json-schema-tools/meta-schema": "^1.7.0",
@@ -79,11 +79,11 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.10.6",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.6.tgz",
-      "integrity": "sha512-xP58G7wDQ4TCmN/cMUHh00DS7SRDv/+lC+xFLrTkMIN8h55X5NhZMLYbvy7dSELP15qlI6hPhNCRWVMtZMwqLA==",
+      "version": "1.10.9",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.9.tgz",
+      "integrity": "sha512-5tcgUctCG0qoNyfChZifz2tJqbRbXVO9J7X6duFcOjY3HUNCxg5D0ZCK7EP9vIcZ0zRpLU9bWkyCqVCLZ46IbQ==",
       "dependencies": {
-        "@grpc/proto-loader": "^0.7.10",
+        "@grpc/proto-loader": "^0.7.13",
         "@js-sdsl/ordered-map": "^4.4.2"
       },
       "engines": {
@@ -91,13 +91,13 @@
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.7.12",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.12.tgz",
-      "integrity": "sha512-DCVwMxqYzpUCiDMl7hQ384FqP4T3DbNpXU8pt681l3UWCip1WUiD5JrkImUwCB9a7f2cq4CUTmi5r/xIMRPY1Q==",
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.13.tgz",
+      "integrity": "sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==",
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
-        "protobufjs": "^7.2.4",
+        "protobufjs": "^7.2.5",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -2272,22 +2272,22 @@
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.10.6",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.6.tgz",
-      "integrity": "sha512-xP58G7wDQ4TCmN/cMUHh00DS7SRDv/+lC+xFLrTkMIN8h55X5NhZMLYbvy7dSELP15qlI6hPhNCRWVMtZMwqLA==",
+      "version": "1.10.9",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.9.tgz",
+      "integrity": "sha512-5tcgUctCG0qoNyfChZifz2tJqbRbXVO9J7X6duFcOjY3HUNCxg5D0ZCK7EP9vIcZ0zRpLU9bWkyCqVCLZ46IbQ==",
       "requires": {
-        "@grpc/proto-loader": "^0.7.10",
+        "@grpc/proto-loader": "^0.7.13",
         "@js-sdsl/ordered-map": "^4.4.2"
       }
     },
     "@grpc/proto-loader": {
-      "version": "0.7.12",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.12.tgz",
-      "integrity": "sha512-DCVwMxqYzpUCiDMl7hQ384FqP4T3DbNpXU8pt681l3UWCip1WUiD5JrkImUwCB9a7f2cq4CUTmi5r/xIMRPY1Q==",
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.13.tgz",
+      "integrity": "sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==",
       "requires": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
-        "protobufjs": "^7.2.4",
+        "protobufjs": "^7.2.5",
         "yargs": "^17.7.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hasura/ndc-sdk-typescript",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/schema/schema.generated.json
+++ b/src/schema/schema.generated.json
@@ -89,9 +89,6 @@
     "QueryCapabilities": {
       "title": "Query Capabilities",
       "type": "object",
-      "required": [
-        "nested_fields"
-      ],
       "properties": {
         "aggregates": {
           "description": "Does the connector support aggregate queries",
@@ -128,6 +125,7 @@
         },
         "nested_fields": {
           "description": "Does the connector support nested fields",
+          "default": {},
           "allOf": [
             {
               "$ref": "#/definitions/NestedFieldCapabilities"
@@ -157,6 +155,17 @@
         },
         "order_by": {
           "description": "Does the connector support ordering by values of nested fields",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "aggregates": {
+          "description": "Does the connector support aggregating values within nested fields",
           "anyOf": [
             {
               "$ref": "#/definitions/LeafCapability"
@@ -1182,6 +1191,16 @@
               "description": "The column to apply the count aggregate function to",
               "type": "string"
             },
+            "field_path": {
+              "description": "Path to a nested field within an object column",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
             "distinct": {
               "description": "Whether or not only distinct items should be counted",
               "type": "boolean"
@@ -1205,6 +1224,16 @@
             "column": {
               "description": "The column to apply the aggregation function to",
               "type": "string"
+            },
+            "field_path": {
+              "description": "Path to a nested field within an object column",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
             },
             "function": {
               "description": "Single column aggregate function name.",
@@ -1543,6 +1572,16 @@
             "column": {
               "description": "The column to apply the aggregation function to",
               "type": "string"
+            },
+            "field_path": {
+              "description": "Path to a nested field within an object column",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
             },
             "function": {
               "description": "Single column aggregate function name.",

--- a/src/schema/schema.generated.ts
+++ b/src/schema/schema.generated.ts
@@ -132,6 +132,10 @@ export type Aggregate =
        */
       column: string;
       /**
+       * Path to a nested field within an object column
+       */
+      field_path?: string[] | null;
+      /**
        * Whether or not only distinct items should be counted
        */
       distinct: boolean;
@@ -142,6 +146,10 @@ export type Aggregate =
        * The column to apply the aggregation function to
        */
       column: string;
+      /**
+       * Path to a nested field within an object column
+       */
+      field_path?: string[] | null;
       /**
        * Single column aggregate function name.
        */
@@ -222,6 +230,10 @@ export type OrderByTarget =
        * The column to apply the aggregation function to
        */
       column: string;
+      /**
+       * Path to a nested field within an object column
+       */
+      field_path?: string[] | null;
       /**
        * Single column aggregate function name.
        */
@@ -398,7 +410,7 @@ export interface QueryCapabilities {
   /**
    * Does the connector support nested fields
    */
-  nested_fields: NestedFieldCapabilities;
+  nested_fields?: NestedFieldCapabilities;
 }
 /**
  * A unit value to indicate a particular leaf capability is supported. This is an empty struct to allow for future sub-capabilities.
@@ -413,6 +425,10 @@ export interface NestedFieldCapabilities {
    * Does the connector support ordering by values of nested fields
    */
   order_by?: LeafCapability | null;
+  /**
+   * Does the connector support aggregating values within nested fields
+   */
+  aggregates?: LeafCapability | null;
 }
 export interface MutationCapabilities {
   /**

--- a/typegen/Cargo.toml
+++ b/typegen/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.3" }
+ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.4" }
 schemars = "0.8.15"
 serde = "^1.0"
 serde_json = "1.0.107"


### PR DESCRIPTION
This PR updates the ndc-spec version support to [v0.1.4](https://hasura.github.io/ndc-spec/specification/changelog.html#014). This is a non-breaking change.

This bumps the version to v5.1.0 from v5.0.0.