### PR TITLE
listen on all ipv4 and ipv6 interfaces by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- The connector now listens on both ipv4 and ipv6 interfaces by default. This can be configured by using the `HASURA_CONNECTOR_HOST` environment variable, which sets the host the web server listens on.
+
 ## 5.1.0
 - Updated to support [v0.1.4 of the NDC Spec](https://hasura.github.io/ndc-spec/specification/changelog.html#014) ([#33](https://github.com/hasura/ndc-sdk-typescript/pull/33))
   - Support for [aggregates](https://hasura.github.io/ndc-spec/specification/queries/aggregates.html) over nested fields

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,11 @@ export function getServeCommand<Configuration, State>(
         .makeOptionMandatory(true)
     )
     .addOption(
+      new Option("--host <host>")
+        .env("HASURA_CONNECTOR_HOST")
+        .default("::")
+    )
+    .addOption(
       new Option("--port <port>")
         .env("HASURA_CONNECTOR_PORT")
         .default(8080)

--- a/src/server.ts
+++ b/src/server.ts
@@ -60,6 +60,7 @@ const errorResponses = {
 
 export interface ServerOptions {
   configuration: string;
+  host: string;
   port: number;
   serviceTokenSecret: string | undefined;
   logLevel: string;
@@ -312,7 +313,7 @@ export async function startServer<Configuration, State>(
   });
 
   try {
-    await server.listen({ port: options.port, host: "::" });
+    await server.listen({ port: options.port, host: options.host });
   } catch (error) {
     server.log.error(error);
     process.exitCode = 1;

--- a/src/server.ts
+++ b/src/server.ts
@@ -312,7 +312,7 @@ export async function startServer<Configuration, State>(
   });
 
   try {
-    await server.listen({ port: options.port, host: "0.0.0.0" });
+    await server.listen({ port: options.port, host: "::" });
   } catch (error) {
     server.log.error(error);
     process.exitCode = 1;


### PR DESCRIPTION
`::` makes the server listen on ipv6 and ipv4 interfaces available