### PR TITLE
Release v5.2.0

### DIFF
--- a/.github/workflows/build_test_publish.yaml
+++ b/.github/workflows/build_test_publish.yaml
@@ -50,3 +50,21 @@ jobs:
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Get version from tag
+        id: get-version
+        run: |
+          echo "tagged_version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - uses: mindsers/changelog-reader-action@v2
+        id: changelog-reader
+        with:
+          version: ${{ steps.get-version.outputs.tagged_version }}
+          path: ./CHANGELOG.md
+
+      - uses: softprops/action-gh-release@v1
+        with:
+          draft: false
+          tag_name: v${{ steps.get-version.outputs.tagged_version }}
+          body: ${{ steps.changelog-reader.outputs.changes }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,58 +1,60 @@
-# Changelog
+# NDC TypeScript SDK Changelog
 
-## Unreleased
-- The connector now listens on both ipv4 and ipv6 interfaces by default. This can be configured by using the `HASURA_CONNECTOR_HOST` environment variable, which sets the host the web server listens on.
+## [5.2.0] - 2024-07-30
+- The connector now listens on both ipv4 and ipv6 interfaces by default. This can be configured by using the `HASURA_CONNECTOR_HOST` environment variable, which sets the host the web server listens on. ([#34](https://github.com/hasura/ndc-sdk-typescript/pull/34))
+- Updated to support [v0.1.5 of the NDC Spec](https://hasura.github.io/ndc-spec/specification/changelog.html#015) ([#35](https://github.com/hasura/ndc-sdk-typescript/pull/35))
+  - There are no real changes in this version; it is a version number-only change
 
-## 5.1.0
+## [5.1.0] - 2024-06-19
 - Updated to support [v0.1.4 of the NDC Spec](https://hasura.github.io/ndc-spec/specification/changelog.html#014) ([#33](https://github.com/hasura/ndc-sdk-typescript/pull/33))
   - Support for [aggregates](https://hasura.github.io/ndc-spec/specification/queries/aggregates.html) over nested fields
 
-## 5.0.0
+## [5.0.0] - 2024-05-31
 - Updated to support [v0.1.3 of the NDC Spec](https://hasura.github.io/ndc-spec/specification/changelog.html#013) ([#32](https://github.com/hasura/ndc-sdk-typescript/pull/32))
   - Breaking change: new `nested_fields` property on `QueryCapabilities`; set it to `{}` to retain previous v0.1.2 semantics and not support new v0.1.3 capabilities.
   - Support [field arguments](https://hasura.github.io/ndc-spec/specification/queries/arguments.html#field-arguments)
   - Support [filtering](https://hasura.github.io/ndc-spec/specification/queries/filtering.html#referencing-nested-fields-within-columns) and [ordering](https://hasura.github.io/ndc-spec/specification/queries/sorting.html#type-column) by nested fields
   - Added a [`biginteger` type representation](https://hasura.github.io/ndc-spec/specification/schema/scalar-types.html#type-representations)
 
-## 4.6.0
+## [4.6.0] - 2024-04-17
 - Use [`prom-client`](https://github.com/siimon/prom-client) to implement the metrics endpoint ([#29](https://github.com/hasura/ndc-sdk-typescript/pull/29))
 - Allow any error code in custom HTTP responses ([#30](https://github.com/hasura/ndc-sdk-typescript/pull/30))
 
-## 4.5.0
+## [4.5.0] - 2024-04-17
 - Support [b3](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-propagator-b3#b3-formats) (zipkin) OpenTelemetry trace propagation headers ([#28](https://github.com/hasura/ndc-sdk-typescript/pull/28))
 
-## 4.4.0
+## [4.4.0] - 2024-04-05
 - Updated to support [v0.1.2 of the NDC Spec](https://hasura.github.io/ndc-spec/specification/changelog.html#012)
   - More precise [type representations](https://hasura.github.io/ndc-spec/specification/schema/scalar-types.html#type-representations) of scalar types were added and the general numeric ones were deprecated (`number` and `integer`)
 
-## 4.3.0
+## [4.3.0] - 2024-03-26
 - Updated to support [v0.1.1 of the NDC Spec](https://hasura.github.io/ndc-spec/specification/changelog.html#011)
   - A more [precise definition of equality operators](https://hasura.github.io/ndc-spec/specification/schema/scalar-types.html#note-syntactic-equality)
   - Scalar types can now [specify a representation](https://hasura.github.io/ndc-spec/specification/schema/scalar-types.html#type-representations), including an enum representation
 
-## 4.2.1
+## [4.2.1] - 2024-02-28
 - Add `main` and `types` properties to the `package.json` to enable `node10` module resolution to be used by projects using legacy TypeScript compiler settings
 
-## 4.2.0
+## [4.2.0] - 2024-02-23
 - OpenTelemetry spans are now attributed with `internal.visibility: "user"` so that they show up in the Hasura Console
 - `@hasura/ndc-sdk-typescript/instrumentation` now exports `withActiveSpan` to wrap a span around a function and `withInternalActiveSpan` which does the same but without the `internal.visibility: "user"` attribute.
 - Automatic OpenTelemetry instrumentation for fetch requests has been added
 
-## 4.1.0
+## [4.1.0] - 2024-02-21
 - Add OpenTelemetry support
   - Set env var `OTEL_EXPORTER_OTLP_ENDPOINT` to the endpoint to send OpenTelemetry to
   - `OTEL_SERVICE_NAME` overrides the service name
   - Command line arguments `--otlp-endpoint` and `--service-name` have been removed in favour of the environment variables
   - Import `@hasura/ndc-sdk-typescript/instrumentation` to use `initTelemetry` to initialize OpenTelemetry earlier in your startup, if necessary
 
-## 1.3.0
+## [1.3.0] - 2024-02-21
 - Add OpenTelemetry support
   - Set env var `OTEL_EXPORTER_OTLP_ENDPOINT` to the endpoint to send OpenTelemetry to
   - `OTEL_SERVICE_NAME` overrides the service name
   - Command line arguments `--otlp_endpoint` and `--service-name` have been removed in favour of the environment variables
   - Import `@hasura/ndc-sdk-typescript/instrumentation` to use `initTelemetry` to initialize OpenTelemetry earlier in your startup, if necessary
 
-## 4.0.0
+## [4.0.0] - 2024-02-19
 Breaking change: support for the [Connector Deployment Spec](https://github.com/hasura/ndc-hub/blob/main/rfcs/0000-deployment.md).
 
 - The connector configuration server has been removed
@@ -69,14 +71,14 @@ Breaking change: support for the [Connector Deployment Spec](https://github.com/
   - The `LOG_LEVEL` environment variable has changed to `HASURA_LOG_LEVEL`
   - The `PRETTY_PRINT_LOGS` environment variable has changed to `HASURA_PRETTY_PRINT_LOGS`
 
-## 3.0.0
+## [3.0.0] - 2024-02-13
 Breaking change: support for the [v0.1.0-rc.15 of NDC Spec](https://github.com/hasura/ndc-spec/compare/v0.1.0-rc.14...v0.1.0-rc.15).
 
 - The [mutation request/response format has changed](https://github.com/hasura/ndc-spec/pull/90).
   - `MutationOperation` fields are now defined as a `NestedField`
   - `MutationOperationResponse` now returns a single value rather than a rowset
 
-## 2.0.0
+## [2.0.0] - 2024-02-05
 Breaking change: support for the [v0.1.0-rc.14 of NDC Spec](https://github.com/hasura/ndc-spec/compare/v0.1.0-rc.13...v0.1.0-rc.14).
 
 - Function name formatting is now standard JavaScript `camelCase`. NDC types used for wire-transmission match the spec (snake_cased).
@@ -93,18 +95,16 @@ Breaking change: support for the [v0.1.0-rc.14 of NDC Spec](https://github.com/h
   - `explain` capability moved to `query.explain`. `mutation.explain` capability added.
 - `ComparisonOperatorDefinition` now has `equal` and `in` as [two standard definitions](https://github.com/hasura/ndc-spec/pull/79/files) and custom operators can be defined. The equality operator is no longer required to be defined and must be explicitly defined.
 
-## 1.2.8
+## [1.2.8] - 2024-01-18
 - Add new `ConnectorError` types:
   - `UnprocessableContent`: The request could not be handled because, while the request was well-formed, it was not semantically correct. For example, a value for a custom scalar type was provided, but with an incorrect type
   - `BadGateway`: The request could not be handled because an upstream service was unavailable or returned an unexpected response, e.g., a connection to a database server failed
 - Generate TypeScript declaration maps for better "go to definition" tooling
 
-## 1.2.7
-
+## [1.2.7] - 2023-12-21
 - `get_serve_command` and `get_serve_configuration_command` now support creation without
   automatically starting servers. This allows usage in scenarios where a customized server startup
   is desired.
 
-## 1.2.6
-
+## [1.2.6] - 2023-12-15
 - added auth hook using secret token

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,14 +238,16 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "ndc-models"
-version = "0.1.4"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.4#20172e3b2552b78d16dbafcd047f559ced420309"
+version = "0.1.5"
+source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.5#78f52768bd02a8289194078a5abc2432c8e3a758"
 dependencies = [
  "indexmap 2.2.6",
+ "ref-cast",
  "schemars",
  "serde",
  "serde_json",
  "serde_with",
+ "smol_str",
 ]
 
 [[package]]
@@ -291,6 +293,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf0a6f84d5f1d581da8b41b47ec8600871962f2a528115b542b362d4b744931"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
 ]
 
 [[package]]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hasura/ndc-sdk-typescript",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hasura/ndc-sdk-typescript",
-      "version": "5.1.0",
+      "version": "5.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@json-schema-tools/meta-schema": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hasura/ndc-sdk-typescript",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/typegen/Cargo.toml
+++ b/typegen/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.4" }
+ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.5" }
 schemars = "0.8.15"
 serde = "^1.0"
 serde_json = "1.0.107"


### PR DESCRIPTION
This PR prepares the v5.2.0 release. 

It also updates the rust sdk version, which is a no-op, since there we no changes in the NDC spec types for that version.

The changelog is converted to Keep a Changelog format and the creating of a GitHub release is automated in CI upon release.