### PR TITLE
Stop authenticating healthchecks and automatically handle the NDC version in capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NDC TypeScript SDK Changelog
 
+## [6.0.0] - 2024-08-08
+Breaking changes ([#36](https://github.com/hasura/ndc-sdk-typescript/pull/36)):
+- `Connector.healthCheck` has been removed and replaced with `Connector.getHealthReadiness`, which only returns whether the connector is able to accept requests, not whether any underlying connections to data sources actually work.
+- The `/health` endpoint is now unauthorized, allowing healthchecks to be performed without authorization.
+- `Connector.getCapabilities` now returns `Capabilities` instead of `CapabilitiesResponse`. The SDK will now take care of adding the correct NDC version to the `Capabilities` on behalf of the connector.
+
 ## [5.2.0] - 2024-07-30
 - The connector now listens on both ipv4 and ipv6 interfaces by default. This can be configured by using the `HASURA_CONNECTOR_HOST` environment variable, which sets the host the web server listens on. ([#34](https://github.com/hasura/ndc-sdk-typescript/pull/34))
 - Updated to support [v0.1.5 of the NDC Spec](https://hasura.github.io/ndc-spec/specification/changelog.html#015) ([#35](https://github.com/hasura/ndc-sdk-typescript/pull/35))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hasura/ndc-sdk-typescript",
-  "version": "5.2.0",
+  "version": "6.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hasura/ndc-sdk-typescript",
-      "version": "5.2.0",
+      "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@json-schema-tools/meta-schema": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hasura/ndc-sdk-typescript",
-  "version": "5.2.0",
+  "version": "6.0.0",
   "description": "",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -1,6 +1,6 @@
 import { Registry } from "prom-client";
 import {
-  CapabilitiesResponse,
+  Capabilities,
   QueryRequest,
   QueryResponse,
   SchemaResponse,
@@ -35,6 +35,7 @@ export interface Connector<Configuration, State> {
     configuration: Configuration,
     metrics: Registry
   ): Promise<State>;
+
   /**
    *
    * Update any metrics from the state
@@ -70,10 +71,10 @@ export interface Connector<Configuration, State> {
    * This function implements the [capabilities endpoint](https://hasura.github.io/ndc-spec/specification/capabilities.html)
    * from the NDC specification.
    *
-   * This function should be syncronous
+   * This function should be synchronous
    * @param configuration
    */
-  getCapabilities(configuration: Configuration): CapabilitiesResponse;
+  getCapabilities(configuration: Configuration): Capabilities;
 
   /**
    * Get the connector's schema.

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -48,17 +48,21 @@ export interface Connector<Configuration, State> {
    * @param state
    */
   fetchMetrics(configuration: Configuration, state: State): Promise<undefined>;
+
   /**
    * Check the health of the connector.
    *
-   * For example, this function should check that the connector
-   * is able to reach its data source over the network.
+   * This should simply verify that the connector is ready to start accepting
+   * requests. It should not verify that external data sources are available.
    *
-   * Should throw if the check fails, else resolve
+   * This function is optional to implement; if left unimplemented, a default
+   * implementation will be used that returns healthy once the connector
+   * webserver is running.
+   *
    * @param configuration
    * @param state
    */
-  healthCheck(configuration: Configuration, state: State): Promise<undefined>;
+  getHealthReadiness?(configuration: Configuration, state: State): Promise<undefined>;
 
   /**
    * Get the connector's capabilities.

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -1,5 +1,6 @@
 import { JSONSchemaObject } from "@json-schema-tools/meta-schema";
 import schema from "./schema.generated.json";
+import { VERSION } from "./version.generated";
 
 function schemaForType(type_name: string): JSONSchemaObject {
   return {
@@ -29,5 +30,6 @@ export {
   MutationRequestSchema,
   MutationResponseSchema,
   ErrorResponseSchema,
-  ValidateResponseSchema
+  ValidateResponseSchema,
+  VERSION,
 };

--- a/src/schema/version.generated.ts
+++ b/src/schema/version.generated.ts
@@ -1,0 +1,1 @@
+export const VERSION = "0.1.5";

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,5 @@
 import Fastify, { FastifyRequest } from "fastify";
 import opentelemetry, {
-  Attributes,
-  Span,
   SpanStatusCode,
 } from "@opentelemetry/api";
 
@@ -23,6 +21,7 @@ import {
   MutationResponse,
   MutationRequest,
   QueryRequest,
+  VERSION
 } from "./schema";
 
 import { Options as AjvOptions } from "ajv";
@@ -136,7 +135,10 @@ export async function startServer<Configuration, State>(
       return withActiveSpan(
         tracer,
         "getCapabilities",
-        () => connector.getCapabilities(configuration)
+        () => ({
+          version: VERSION,
+          capabilities: connector.getCapabilities(configuration),
+        })
       );
     }
   );

--- a/typegen/regenerate-schema.sh
+++ b/typegen/regenerate-schema.sh
@@ -2,7 +2,7 @@
 set -eu -o pipefail
 
 # Generate JSON schema from Rust types
-cargo run -- ./src/schema/schema.generated.json
+cargo run -- ./src/schema
 
 # Generate TypeScript types from JSON schema
 json2ts -i ./src/schema/schema.generated.json -o ./src/schema/schema.generated.ts --no-additionalProperties


### PR DESCRIPTION
- `Connector.healthCheck` has been removed and replaced with `Connector.getHealthReadiness`, which only returns whether the connector is able to accept requests, not whether any underlying connections to data sources actually work.
- The `/health` endpoint is now unauthorized, allowing healthchecks to be performed without authorization.
- `Connector.getCapabilities` now returns `Capabilities` instead of `CapabilitiesResponse`. The SDK will now take care of adding the correct NDC version to the `Capabilities` on behalf of the connector.