### PR TITLE
Updated to support NDC Spec v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # NDC TypeScript SDK Changelog
 
+## [6.1.0] - 2024-08-26
+- Updated to support [v0.1.6 of the NDC Spec](https://hasura.github.io/ndc-spec/specification/changelog.html#016) ([#37](https://github.com/hasura/ndc-sdk-typescript/pull/37))
+  - Support for [querying nested collections](https://hasura.github.io/ndc-spec/specification/queries/filtering.html#nested-collections) inside an EXISTS expression in a predicate
+
 ## [6.0.0] - 2024-08-08
 Breaking changes ([#36](https://github.com/hasura/ndc-sdk-typescript/pull/36)):
 - `Connector.healthCheck` has been removed and replaced with `Connector.getHealthReadiness`, which only returns whether the connector is able to accept requests, not whether any underlying connections to data sources actually work.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,8 +238,8 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "ndc-models"
-version = "0.1.5"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.5#78f52768bd02a8289194078a5abc2432c8e3a758"
+version = "0.1.6"
+source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.1.6#d1be19e9cdd86ac7b6ad003ff82b7e5b4e96b84f"
 dependencies = [
  "indexmap 2.2.6",
  "ref-cast",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hasura/ndc-sdk-typescript",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hasura/ndc-sdk-typescript",
-      "version": "6.0.0",
+      "version": "6.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@json-schema-tools/meta-schema": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hasura/ndc-sdk-typescript",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/schema/schema.generated.json
+++ b/src/schema/schema.generated.json
@@ -131,6 +131,15 @@
               "$ref": "#/definitions/NestedFieldCapabilities"
             }
           ]
+        },
+        "exists": {
+          "description": "Does the connector support EXISTS predicates",
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExistsCapabilities"
+            }
+          ]
         }
       }
     },
@@ -166,6 +175,23 @@
         },
         "aggregates": {
           "description": "Does the connector support aggregating values within nested fields",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "ExistsCapabilities": {
+      "title": "Exists Capabilities",
+      "type": "object",
+      "properties": {
+        "nested_collections": {
+          "description": "Does the connector support ExistsInCollection::NestedCollection",
           "anyOf": [
             {
               "$ref": "#/definitions/LeafCapability"
@@ -684,7 +710,7 @@
               ]
             },
             "name": {
-              "description": "The name can refer to a primitive type or a scalar type",
+              "description": "The name can refer to a scalar or object type",
               "type": "string"
             }
           }
@@ -1980,6 +2006,37 @@
               "type": "object",
               "additionalProperties": {
                 "$ref": "#/definitions/RelationshipArgument"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "column_name",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "nested_collection"
+              ]
+            },
+            "column_name": {
+              "type": "string"
+            },
+            "arguments": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/Argument"
+              }
+            },
+            "field_path": {
+              "description": "Path to a nested collection via object columns",
+              "type": "array",
+              "items": {
+                "type": "string"
               }
             }
           }

--- a/src/schema/schema.generated.ts
+++ b/src/schema/schema.generated.ts
@@ -82,7 +82,7 @@ export type Type =
   | {
       type: "named";
       /**
-       * The name can refer to a primitive type or a scalar type
+       * The name can refer to a scalar or object type
        */
       name: string;
     }
@@ -343,6 +343,17 @@ export type ExistsInCollection =
       arguments: {
         [k: string]: RelationshipArgument;
       };
+    }
+  | {
+      type: "nested_collection";
+      column_name: string;
+      arguments?: {
+        [k: string]: Argument;
+      };
+      /**
+       * Path to a nested collection via object columns
+       */
+      field_path?: string[];
     };
 export type RelationshipType = "object" | "array";
 /**
@@ -411,6 +422,10 @@ export interface QueryCapabilities {
    * Does the connector support nested fields
    */
   nested_fields?: NestedFieldCapabilities;
+  /**
+   * Does the connector support EXISTS predicates
+   */
+  exists?: ExistsCapabilities;
 }
 /**
  * A unit value to indicate a particular leaf capability is supported. This is an empty struct to allow for future sub-capabilities.
@@ -429,6 +444,12 @@ export interface NestedFieldCapabilities {
    * Does the connector support aggregating values within nested fields
    */
   aggregates?: LeafCapability | null;
+}
+export interface ExistsCapabilities {
+  /**
+   * Does the connector support ExistsInCollection::NestedCollection
+   */
+  nested_collections?: LeafCapability | null;
 }
 export interface MutationCapabilities {
   /**

--- a/src/schema/version.generated.ts
+++ b/src/schema/version.generated.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.1.5";
+export const VERSION = "0.1.6";

--- a/typegen/Cargo.toml
+++ b/typegen/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.5" }
+ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.1.6" }
 schemars = "0.8.15"
 serde = "^1.0"
 serde_json = "1.0.107"


### PR DESCRIPTION
This PR updates the SDK types to NDC v0.1.6. This updates the TS SDK version to v6.1.0 as it does not introduce any breaking changes.