### PR TITLE
Update to NDC v0.2.0-rc.3 and bump version to 8.0.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased changes
 
+## [8.0.0-rc.1] - 2025-01-30
+- Updated to support the latest release candidate (rc.3) of [v0.2.0 of the NDC Spec](https://hasura.github.io/ndc-spec/specification/changelog.html#020)
+
 ## [8.0.0-rc.0] - 2025-01-08
 **Breaking changes** ([#39](https://github.com/hasura/ndc-sdk-typescript/pull/39), [#40](https://github.com/hasura/ndc-sdk-typescript/pull/40)):
 - Updated to support [v0.2.0 of the NDC Spec](https://hasura.github.io/ndc-spec/specification/changelog.html#020). This is a very large update which adds new features and some breaking changes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,7 +239,7 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 [[package]]
 name = "ndc-models"
 version = "0.2.0"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.2.0-rc.2#2fad1c699df79890dbb3877d1035ffd8bd0abfc2"
+source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.2.0-rc.3#9c202b92fd72be93b6a180f6b8dbf70607eca7b4"
 dependencies = [
  "indexmap 2.2.6",
  "ref-cast",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hasura/ndc-sdk-typescript",
-  "version": "8.0.0-rc.0",
+  "version": "8.0.0-rc.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hasura/ndc-sdk-typescript",
-      "version": "8.0.0-rc.0",
+      "version": "8.0.0-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@json-schema-tools/meta-schema": "^1.7.0",
@@ -32,7 +32,7 @@
         "@types/node": "^18.11.9",
         "@types/semver": "^7.5.8",
         "json-schema-to-typescript": "^13.1.1",
-        "typescript": "^5.6.3"
+        "typescript": "^5.7.3"
       }
     },
     "node_modules/@bcherny/json-schema-ref-parser": {
@@ -2766,9 +2766,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -4869,9 +4869,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true
     },
     "undici-types": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hasura/ndc-sdk-typescript",
-  "version": "8.0.0-rc.0",
+  "version": "8.0.0-rc.1",
   "description": "",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -43,6 +43,6 @@
     "@types/node": "^18.11.9",
     "@types/semver": "^7.5.8",
     "json-schema-to-typescript": "^13.1.1",
-    "typescript": "^5.6.3"
+    "typescript": "^5.7.3"
   }
 }

--- a/src/schema/schema.generated.json
+++ b/src/schema/schema.generated.json
@@ -533,6 +533,14 @@
           "additionalProperties": {
             "$ref": "#/definitions/ComparisonOperatorDefinition"
           }
+        },
+        "extraction_functions": {
+          "description": "A map from extraction function names to their definitions.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ExtractionFunctionDefinition"
+          }
         }
       }
     },
@@ -1210,6 +1218,263 @@
             },
             "argument_type": {
               "description": "The type of the argument to this operator",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Type"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "ExtractionFunctionDefinition": {
+      "title": "Extraction Function Definition",
+      "description": "The definition of an aggregation function on a scalar type",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "result_type",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "nanosecond"
+              ]
+            },
+            "result_type": {
+              "description": "The result type, which must be a defined scalar type in the schema response.",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "result_type",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "microsecond"
+              ]
+            },
+            "result_type": {
+              "description": "The result type, which must be a defined scalar type in the schema response.",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "result_type",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "second"
+              ]
+            },
+            "result_type": {
+              "description": "The result type, which must be a defined scalar type in the schema response.",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "result_type",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "minute"
+              ]
+            },
+            "result_type": {
+              "description": "The result type, which must be a defined scalar type in the schema response.",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "result_type",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "hour"
+              ]
+            },
+            "result_type": {
+              "description": "The result type, which must be a defined scalar type in the schema response.",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "result_type",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "day"
+              ]
+            },
+            "result_type": {
+              "description": "The result type, which must be a defined scalar type in the schema response.",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "result_type",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "week"
+              ]
+            },
+            "result_type": {
+              "description": "The result type, which must be a defined scalar type in the schema response.",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "result_type",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "month"
+              ]
+            },
+            "result_type": {
+              "description": "The result type, which must be a defined scalar type in the schema response.",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "result_type",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "quarter"
+              ]
+            },
+            "result_type": {
+              "description": "The result type, which must be a defined scalar type in the schema response.",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "result_type",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "year"
+              ]
+            },
+            "result_type": {
+              "description": "The result type, which must be a defined scalar type in the schema response.",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "result_type",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "day_of_week"
+              ]
+            },
+            "result_type": {
+              "description": "The result type, which must be a defined scalar type in the schema response.",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "result_type",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "day_of_year"
+              ]
+            },
+            "result_type": {
+              "description": "The result type, which must be a defined scalar type in the schema response.",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "result_type",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "custom"
+              ]
+            },
+            "result_type": {
+              "description": "The scalar or object type of the result of this function",
               "allOf": [
                 {
                   "$ref": "#/definitions/Type"
@@ -2763,6 +3028,13 @@
               "items": {
                 "type": "string"
               }
+            },
+            "extraction": {
+              "description": "The name of the extraction function to apply to the selected value, if any",
+              "type": [
+                "string",
+                "null"
+              ]
             }
           }
         }

--- a/src/schema/schema.generated.ts
+++ b/src/schema/schema.generated.ts
@@ -177,6 +177,101 @@ export type ComparisonOperatorDefinition =
        */
       argument_type: Type;
     };
+/**
+ * The definition of an aggregation function on a scalar type
+ */
+export type ExtractionFunctionDefinition =
+  | {
+      type: "nanosecond";
+      /**
+       * The result type, which must be a defined scalar type in the schema response.
+       */
+      result_type: string;
+    }
+  | {
+      type: "microsecond";
+      /**
+       * The result type, which must be a defined scalar type in the schema response.
+       */
+      result_type: string;
+    }
+  | {
+      type: "second";
+      /**
+       * The result type, which must be a defined scalar type in the schema response.
+       */
+      result_type: string;
+    }
+  | {
+      type: "minute";
+      /**
+       * The result type, which must be a defined scalar type in the schema response.
+       */
+      result_type: string;
+    }
+  | {
+      type: "hour";
+      /**
+       * The result type, which must be a defined scalar type in the schema response.
+       */
+      result_type: string;
+    }
+  | {
+      type: "day";
+      /**
+       * The result type, which must be a defined scalar type in the schema response.
+       */
+      result_type: string;
+    }
+  | {
+      type: "week";
+      /**
+       * The result type, which must be a defined scalar type in the schema response.
+       */
+      result_type: string;
+    }
+  | {
+      type: "month";
+      /**
+       * The result type, which must be a defined scalar type in the schema response.
+       */
+      result_type: string;
+    }
+  | {
+      type: "quarter";
+      /**
+       * The result type, which must be a defined scalar type in the schema response.
+       */
+      result_type: string;
+    }
+  | {
+      type: "year";
+      /**
+       * The result type, which must be a defined scalar type in the schema response.
+       */
+      result_type: string;
+    }
+  | {
+      type: "day_of_week";
+      /**
+       * The result type, which must be a defined scalar type in the schema response.
+       */
+      result_type: string;
+    }
+  | {
+      type: "day_of_year";
+      /**
+       * The result type, which must be a defined scalar type in the schema response.
+       */
+      result_type: string;
+    }
+  | {
+      type: "custom";
+      /**
+       * The scalar or object type of the result of this function
+       */
+      result_type: Type;
+    };
 export type Aggregate =
   | {
       type: "column_count";
@@ -485,6 +580,10 @@ export type Dimension = {
    * Path to a nested field within an object column
    */
   field_path?: string[] | null;
+  /**
+   * The name of the extraction function to apply to the selected value, if any
+   */
+  extraction?: string | null;
 };
 export type GroupExpression =
   | {
@@ -769,6 +868,12 @@ export interface ScalarType {
    */
   comparison_operators: {
     [k: string]: ComparisonOperatorDefinition;
+  };
+  /**
+   * A map from extraction function names to their definitions.
+   */
+  extraction_functions?: {
+    [k: string]: ExtractionFunctionDefinition;
   };
 }
 /**

--- a/typegen/Cargo.toml
+++ b/typegen/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.2.0-rc.2" }
+ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.2.0-rc.3" }
 schemars = "^0.8"
 serde = "^1.0"
 serde_json = "^1.0"


### PR DESCRIPTION
This PR updates to ndc-spec v0.2.0-rc.3 and bumps the package version v8.0.0-rc.1.

It also updates the version of TypeScript used to build.