### PR TITLE
Update to NDC v0.2.0 final and bump version to 8.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ## Unreleased changes
 
+## [8.0.0] - 2025-03-13
+**Breaking changes** since v7.0.0 ([#39](https://github.com/hasura/ndc-sdk-typescript/pull/39), [#40](https://github.com/hasura/ndc-sdk-typescript/pull/40), [#42](https://github.com/hasura/ndc-sdk-typescript/pull/42), [#43](https://github.com/hasura/ndc-sdk-typescript/pull/43)):
+- Updated to support [v0.2.0 of the NDC Spec](https://hasura.github.io/ndc-spec/specification/changelog.html#020). This is a very large update which adds new features and some breaking changes.
+- If the [`X-Hasura-NDC-Version`](https://hasura.github.io/ndc-spec/specification/versioning.html) header is sent, the SDK will validate that the connector supports the incoming request's version and reject it if it does not. If no header is sent, no action is taken.
+
 ## [8.0.0-rc.1] - 2025-01-30
-- Updated to support the latest release candidate (rc.3) of [v0.2.0 of the NDC Spec](https://hasura.github.io/ndc-spec/specification/changelog.html#020)
+- Updated to support the latest release candidate (rc.3) of [v0.2.0 of the NDC Spec](https://hasura.github.io/ndc-spec/specification/changelog.html#020) ([#42](https://github.com/hasura/ndc-sdk-typescript/pull/42))
 
 ## [8.0.0-rc.0] - 2025-01-08
 **Breaking changes** ([#39](https://github.com/hasura/ndc-sdk-typescript/pull/39), [#40](https://github.com/hasura/ndc-sdk-typescript/pull/40)):

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,7 +239,7 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 [[package]]
 name = "ndc-models"
 version = "0.2.0"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.2.0-rc.3#9c202b92fd72be93b6a180f6b8dbf70607eca7b4"
+source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.2.0#e25213f51a7e8422d712509d63ae012c67b4f3f1"
 dependencies = [
  "indexmap 2.2.6",
  "ref-cast",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hasura/ndc-sdk-typescript",
-  "version": "8.0.0-rc.1",
+  "version": "8.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hasura/ndc-sdk-typescript",
-      "version": "8.0.0-rc.1",
+      "version": "8.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@json-schema-tools/meta-schema": "^1.7.0",
@@ -32,7 +32,7 @@
         "@types/node": "^18.11.9",
         "@types/semver": "^7.5.8",
         "json-schema-to-typescript": "^13.1.1",
-        "typescript": "^5.7.3"
+        "typescript": "^5.8.2"
       }
     },
     "node_modules/@bcherny/json-schema-ref-parser": {
@@ -2766,9 +2766,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -4869,9 +4869,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true
     },
     "undici-types": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hasura/ndc-sdk-typescript",
-  "version": "8.0.0-rc.1",
+  "version": "8.0.0",
   "description": "",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -43,6 +43,6 @@
     "@types/node": "^18.11.9",
     "@types/semver": "^7.5.8",
     "json-schema-to-typescript": "^13.1.1",
-    "typescript": "^5.7.3"
+    "typescript": "^5.8.2"
   }
 }

--- a/src/schema/schema.generated.json
+++ b/src/schema/schema.generated.json
@@ -440,6 +440,28 @@
               "type": "null"
             }
           ]
+        },
+        "filtering": {
+          "description": "Does the connector support filtering over a relationship that starts from inside a nested object",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ordering": {
+          "description": "Does the connector support ordering over a relationship that starts from inside a nested object",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       }
     },
@@ -2301,7 +2323,7 @@
               ]
             },
             "path": {
-              "description": "Any (object) relationships to traverse to reach this column. Only non-empty if the 'relationships' capability is supported.",
+              "description": "Any (object) relationships to traverse to reach this column. Only non-empty if the 'relationships' capability is supported. 'PathElement.field_path' will only be non-empty if the 'relationships.nested.ordering' capability is supported.",
               "type": "array",
               "items": {
                 "$ref": "#/definitions/PathElement"
@@ -2346,7 +2368,7 @@
               ]
             },
             "path": {
-              "description": "Non-empty collection of relationships to traverse",
+              "description": "Non-empty collection of relationships to traverse. Only non-empty if the 'relationships' capability is supported. 'PathElement.field_path' will only be non-empty if the 'relationships.nested.ordering' capability is supported.",
               "type": "array",
               "items": {
                 "$ref": "#/definitions/PathElement"
@@ -2373,7 +2395,7 @@
       ],
       "properties": {
         "field_path": {
-          "description": "Path to a nested field within an object column that must be navigated before the relationship is navigated. Only non-empty if the 'relationships.nested' capability is supported.",
+          "description": "Path to a nested field within an object column that must be navigated before the relationship is navigated. Only non-empty if the 'relationships.nested' capability is supported (plus perhaps one of the sub-capabilities, depending on the feature using the PathElement).",
           "type": [
             "array",
             "null"
@@ -2804,7 +2826,7 @@
               ]
             },
             "field_path": {
-              "description": "Path to a nested field within an object column that must be navigated before the relationship is navigated Only non-empty if the 'relationships.nested' capability is supported.",
+              "description": "Path to a nested field within an object column that must be navigated before the relationship is navigated. Only non-empty if the 'relationships.nested.filtering' capability is supported.",
               "type": [
                 "array",
                 "null"

--- a/src/schema/schema.generated.ts
+++ b/src/schema/schema.generated.ts
@@ -372,7 +372,7 @@ export type OrderByTarget =
   | {
       type: "column";
       /**
-       * Any (object) relationships to traverse to reach this column. Only non-empty if the 'relationships' capability is supported.
+       * Any (object) relationships to traverse to reach this column. Only non-empty if the 'relationships' capability is supported. 'PathElement.field_path' will only be non-empty if the 'relationships.nested.ordering' capability is supported.
        */
       path: PathElement[];
       /**
@@ -393,7 +393,7 @@ export type OrderByTarget =
   | {
       type: "aggregate";
       /**
-       * Non-empty collection of relationships to traverse
+       * Non-empty collection of relationships to traverse. Only non-empty if the 'relationships' capability is supported. 'PathElement.field_path' will only be non-empty if the 'relationships.nested.ordering' capability is supported.
        */
       path: PathElement[];
       /**
@@ -511,7 +511,7 @@ export type ExistsInCollection =
   | {
       type: "related";
       /**
-       * Path to a nested field within an object column that must be navigated before the relationship is navigated Only non-empty if the 'relationships.nested' capability is supported.
+       * Path to a nested field within an object column that must be navigated before the relationship is navigated. Only non-empty if the 'relationships.nested.filtering' capability is supported.
        */
       field_path?: string[] | null;
       /**
@@ -818,6 +818,14 @@ export interface NestedRelationshipCapabilities {
    * Does the connector support navigating a relationship from inside a nested object inside a nested array
    */
   array?: LeafCapability | null;
+  /**
+   * Does the connector support filtering over a relationship that starts from inside a nested object
+   */
+  filtering?: LeafCapability | null;
+  /**
+   * Does the connector support ordering over a relationship that starts from inside a nested object
+   */
+  ordering?: LeafCapability | null;
 }
 export interface SchemaResponse {
   /**
@@ -1126,7 +1134,7 @@ export interface OrderByElement {
 }
 export interface PathElement {
   /**
-   * Path to a nested field within an object column that must be navigated before the relationship is navigated. Only non-empty if the 'relationships.nested' capability is supported.
+   * Path to a nested field within an object column that must be navigated before the relationship is navigated. Only non-empty if the 'relationships.nested' capability is supported (plus perhaps one of the sub-capabilities, depending on the feature using the PathElement).
    */
   field_path?: string[] | null;
   /**

--- a/typegen/Cargo.toml
+++ b/typegen/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.2.0-rc.3" }
+ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.2.0" }
 schemars = "^0.8"
 serde = "^1.0"
 serde_json = "^1.0"


### PR DESCRIPTION
This PR updates the NDC Spec version used to the final v0.2.0 version and bumps the package version to v8.0.0. 

It also upgrades the Typescript version used to build.