### PR TITLE
Bump Fastify body limit to 30mb.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hasura/ndc-sdk-typescript",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/server.ts
+++ b/src/server.ts
@@ -97,6 +97,7 @@ export async function startServer<Configuration, State>(
 
   const server = Fastify({
     logger: configureFastifyLogging(options),
+    bodyLimit: 1048576 * 30, // 30mb body limit
     ajv: {
       customOptions: customAjvOptions,
     },
@@ -349,7 +350,7 @@ export async function startServer<Configuration, State>(
     }
   );
 
-  server.setErrorHandler(function (error, _request, reply) {
+  server.setErrorHandler(function(error, _request, reply) {
     // pino trace instrumentation will add trace information to log output
     this.log.error(error);
 


### PR DESCRIPTION
Previously we were using the [default](https://fastify.dev/docs/latest/Reference/Server/#bodylimit) of 1mb, let's increase this to 30mb.