### PR TITLE
feat: upgrade ndc-spec v0.2.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,7 +87,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.55",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -98,7 +98,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -237,9 +237,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
 name = "ndc-models"
-version = "0.2.0"
-source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.2.0#e25213f51a7e8422d712509d63ae012c67b4f3f1"
+version = "0.2.12"
+source = "git+http://github.com/hasura/ndc-spec.git?tag=v0.2.12#86af33d8a09228a74499d02a1f838bf9f7a9759f"
 dependencies = [
  "indexmap 2.2.6",
  "ref-cast",
@@ -279,9 +285,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -312,14 +318,8 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.117",
 ]
-
-[[package]]
-name = "ryu"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "schemars"
@@ -350,22 +350,32 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -381,14 +391,16 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "indexmap 2.2.6",
  "itoa",
- "ryu",
+ "memchr",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -418,7 +430,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -449,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.55"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -516,7 +528,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -538,7 +550,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.117",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -614,3 +626,9 @@ name = "windows_x86_64_msvc"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/src/schema/schema.generated.json
+++ b/src/schema/schema.generated.json
@@ -10,6 +10,14 @@
     "mutation_response",
     "query_request",
     "query_response",
+    "relational_delete_request",
+    "relational_delete_response",
+    "relational_insert_request",
+    "relational_insert_response",
+    "relational_query",
+    "relational_query_response",
+    "relational_update_request",
+    "relational_update_response",
     "schema_response",
     "validate_response"
   ],
@@ -40,6 +48,30 @@
     },
     "validate_response": {
       "$ref": "#/definitions/ValidateResponse"
+    },
+    "relational_delete_request": {
+      "$ref": "#/definitions/RelationalDeleteRequest"
+    },
+    "relational_delete_response": {
+      "$ref": "#/definitions/RelationalDeleteResponse"
+    },
+    "relational_insert_request": {
+      "$ref": "#/definitions/RelationalInsertRequest"
+    },
+    "relational_insert_response": {
+      "$ref": "#/definitions/RelationalInsertResponse"
+    },
+    "relational_query": {
+      "$ref": "#/definitions/RelationalQuery"
+    },
+    "relational_query_response": {
+      "$ref": "#/definitions/RelationalQueryResponse"
+    },
+    "relational_update_request": {
+      "$ref": "#/definitions/RelationalUpdateRequest"
+    },
+    "relational_update_response": {
+      "$ref": "#/definitions/RelationalUpdateResponse"
     }
   },
   "definitions": {
@@ -78,6 +110,28 @@
           "anyOf": [
             {
               "$ref": "#/definitions/RelationshipCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "relational_query": {
+          "description": "Does the connector support the relational query API? This feature is experimental and subject to breaking changes within minor versions.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RelationalQueryCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "relational_mutation": {
+          "description": "Does the connector support the relational mutation API? This feature is experimental and subject to breaking changes within minor versions.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RelationalMutationCapabilities"
             },
             {
               "type": "null"
@@ -465,6 +519,1626 @@
         }
       }
     },
+    "RelationalQueryCapabilities": {
+      "title": "Relational Query Capabilities",
+      "description": "Describes which features of the relational query API are supported by the connector. This feature is experimental and subject to breaking changes within minor versions.",
+      "type": "object",
+      "required": [
+        "project"
+      ],
+      "properties": {
+        "project": {
+          "$ref": "#/definitions/RelationalProjectionCapabilities"
+        },
+        "filter": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RelationalExpressionCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sort": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RelationalSortCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "join": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RelationalJoinCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "aggregate": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RelationalAggregateCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "window": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RelationalWindowCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "union": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "streaming": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "RelationalProjectionCapabilities": {
+      "title": "Relational Projection Capabilities",
+      "type": "object",
+      "required": [
+        "expression"
+      ],
+      "properties": {
+        "expression": {
+          "$ref": "#/definitions/RelationalExpressionCapabilities"
+        }
+      }
+    },
+    "RelationalExpressionCapabilities": {
+      "title": "Relational Expression Capabilities",
+      "type": "object",
+      "required": [
+        "aggregate",
+        "comparison",
+        "conditional",
+        "scalar",
+        "window"
+      ],
+      "properties": {
+        "conditional": {
+          "$ref": "#/definitions/RelationalConditionalExpressionCapabilities"
+        },
+        "comparison": {
+          "$ref": "#/definitions/RelationalComparisonExpressionCapabilities"
+        },
+        "scalar": {
+          "$ref": "#/definitions/RelationalScalarExpressionCapabilities"
+        },
+        "aggregate": {
+          "$ref": "#/definitions/RelationalAggregateExpressionCapabilities"
+        },
+        "window": {
+          "$ref": "#/definitions/RelationalWindowExpressionCapabilities"
+        },
+        "scalar_types": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RelationalScalarTypeCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "RelationalConditionalExpressionCapabilities": {
+      "title": "Relational Conditional Expression Capabilities",
+      "type": "object",
+      "properties": {
+        "case": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RelationalCaseCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "nullif": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "RelationalCaseCapabilities": {
+      "title": "Relational Case Capabilities",
+      "type": "object",
+      "properties": {
+        "scrutinee": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "RelationalComparisonExpressionCapabilities": {
+      "title": "Relational Filter Expression Capabilities",
+      "type": "object",
+      "properties": {
+        "between": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "contains": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "greater_than_eq": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "greater_than": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ilike": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "in_list": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "is_distinct_from": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "is_false": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "is_nan": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "is_null": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "is_true": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "is_zero": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "less_than_eq": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "less_than": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "like": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "RelationalScalarExpressionCapabilities": {
+      "title": "Relational Scalar Expression Capabilities",
+      "type": "object",
+      "properties": {
+        "abs": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "and": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "array_element": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "binary_concat": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "btrim": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ceil": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "character_length": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "coalesce": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "concat": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cos": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "current_date": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "current_time": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "current_timestamp": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "date_part": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DatePartScalarExpressionCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "date_trunc": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "divide": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "exp": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "floor": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "get_field": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "greatest": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "least": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "left": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ln": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "log": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "log10": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "log2": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "lpad": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ltrim": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "minus": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "modulo": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "multiply": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "negate": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "not": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "nvl": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "or": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "plus": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "power": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "random": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "replace": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "reverse": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "right": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "round": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "rpad": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "rtrim": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sqrt": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "str_pos": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "substr_index": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "substr": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tan": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "to_date": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "to_lower": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "to_timestamp": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "to_upper": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "trunc": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "json_contains": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "json_get": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "json_get_str": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "json_get_int": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "json_get_float": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "json_get_bool": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "json_get_json": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "json_as_text": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "json_length": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "DatePartScalarExpressionCapability": {
+      "title": "Date Part Scalar Expression Capability",
+      "type": "object",
+      "properties": {
+        "year": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "quarter": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "month": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "week": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "day_of_week": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "day_of_year": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "day": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hour": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "minute": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "second": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "microsecond": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "millisecond": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "nanosecond": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "epoch": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "RelationalAggregateExpressionCapabilities": {
+      "title": "Relational Aggregate Expression Capabilities",
+      "type": "object",
+      "properties": {
+        "avg": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "bool_and": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "bool_or": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "count": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RelationalAggregateFunctionCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "first_value": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "last_value": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "median": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "min": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "string_agg": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RelationalOrderedAggregateFunctionCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "string_agg_with_separator": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RelationalOrderedAggregateFunctionCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sum": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "var": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "stddev": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "stddev_pop": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "approx_percentile_cont": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "array_agg": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RelationalOrderedAggregateFunctionCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "approx_distinct": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "RelationalAggregateFunctionCapabilities": {
+      "title": "Relational Aggregate Function Capabilities",
+      "type": "object",
+      "properties": {
+        "distinct": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "RelationalOrderedAggregateFunctionCapabilities": {
+      "title": "Relational Ordered Aggregate Function Capabilities",
+      "type": "object",
+      "properties": {
+        "distinct": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "order_by": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "RelationalWindowExpressionCapabilities": {
+      "title": "Relational Window Expression Capabilities",
+      "type": "object",
+      "properties": {
+        "row_number": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dense_rank": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ntile": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "rank": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cume_dist": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "percent_rank": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "RelationalScalarTypeCapabilities": {
+      "title": "Relational Scalar Type Capabilities",
+      "type": "object",
+      "properties": {
+        "interval": {
+          "description": "Does the connector support the INTERVAL scalar type? Both interval literals and casts to the INTERVAL type are implied by this capability.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "from_type": {
+          "description": "Does the connector support `from_type` in cast?",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "RelationalSortCapabilities": {
+      "title": "Relational Sort Capabilities",
+      "type": "object",
+      "required": [
+        "expression"
+      ],
+      "properties": {
+        "expression": {
+          "$ref": "#/definitions/RelationalExpressionCapabilities"
+        }
+      }
+    },
+    "RelationalJoinCapabilities": {
+      "title": "Relational Join Capabilities",
+      "type": "object",
+      "required": [
+        "expression",
+        "join_types"
+      ],
+      "properties": {
+        "expression": {
+          "$ref": "#/definitions/RelationalExpressionCapabilities"
+        },
+        "join_types": {
+          "$ref": "#/definitions/RelationalJoinTypeCapabilities"
+        }
+      }
+    },
+    "RelationalJoinTypeCapabilities": {
+      "title": "Relational Join Type Capabilities",
+      "type": "object",
+      "properties": {
+        "left": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "right": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "inner": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "full": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "left_semi": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "left_anti": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "right_semi": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "right_anti": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "RelationalAggregateCapabilities": {
+      "title": "Relational Aggregate Capabilities",
+      "type": "object",
+      "required": [
+        "expression"
+      ],
+      "properties": {
+        "expression": {
+          "$ref": "#/definitions/RelationalExpressionCapabilities"
+        },
+        "group_by": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "RelationalWindowCapabilities": {
+      "title": "Relational Window Capabilities",
+      "type": "object",
+      "required": [
+        "expression"
+      ],
+      "properties": {
+        "expression": {
+          "$ref": "#/definitions/RelationalExpressionCapabilities"
+        }
+      }
+    },
+    "RelationalMutationCapabilities": {
+      "title": "Relational Mutation Capabilities",
+      "description": "Describes which features of the relational mutation API are supported by the connector. This feature is experimental and subject to breaking changes within minor versions.",
+      "type": "object",
+      "properties": {
+        "insert": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "update": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "delete": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LeafCapability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
     "SchemaResponse": {
       "title": "Schema Response",
       "type": "object",
@@ -516,6 +2190,17 @@
           "anyOf": [
             {
               "$ref": "#/definitions/CapabilitySchemaInfo"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "request_arguments": {
+          "description": "Request level arguments which are required for queries and mutations",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RequestLevelArguments"
             },
             {
               "type": "null"
@@ -1302,6 +2987,25 @@
             "type": {
               "type": "string",
               "enum": [
+                "millisecond"
+              ]
+            },
+            "result_type": {
+              "description": "The result type, which must be a defined scalar type in the schema response.",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "result_type",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
                 "second"
               ]
             },
@@ -1657,6 +3361,17 @@
           "additionalProperties": {
             "$ref": "#/definitions/UniquenessConstraint"
           }
+        },
+        "relational_mutations": {
+          "description": "Information about relational mutation capabilities for this collection",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RelationalMutationInfo"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       }
     },
@@ -1673,6 +3388,29 @@
           "items": {
             "type": "string"
           }
+        }
+      }
+    },
+    "RelationalMutationInfo": {
+      "title": "Relational Mutation Info",
+      "type": "object",
+      "required": [
+        "deletable",
+        "insertable",
+        "updatable"
+      ],
+      "properties": {
+        "insertable": {
+          "description": "Whether inserts are supported for this collection",
+          "type": "boolean"
+        },
+        "updatable": {
+          "description": "Whether updates are supported for this collection",
+          "type": "boolean"
+        },
+        "deletable": {
+          "description": "Whether deletes are supported for this collection",
+          "type": "boolean"
         }
       }
     },
@@ -1797,6 +3535,38 @@
         }
       }
     },
+    "RequestLevelArguments": {
+      "title": "Request Level Arguments",
+      "type": "object",
+      "required": [
+        "mutation_arguments",
+        "query_arguments",
+        "relational_query_arguments"
+      ],
+      "properties": {
+        "query_arguments": {
+          "description": "Any arguments that all Query requests require",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ArgumentInfo"
+          }
+        },
+        "mutation_arguments": {
+          "description": "Any arguments that all Mutation requests require",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ArgumentInfo"
+          }
+        },
+        "relational_query_arguments": {
+          "description": "Any arguments that all Relational Query requests require",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ArgumentInfo"
+          }
+        }
+      }
+    },
     "QueryRequest": {
       "title": "Query Request",
       "description": "This is the request body of the query POST endpoint",
@@ -1844,6 +3614,14 @@
             "type": "object",
             "additionalProperties": true
           }
+        },
+        "request_arguments": {
+          "description": "Values to be provided to request-level arguments.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
         }
       }
     },
@@ -3453,6 +5231,14 @@
           "additionalProperties": {
             "$ref": "#/definitions/Relationship"
           }
+        },
+        "request_arguments": {
+          "description": "Values to be provided to request-level arguments.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
         }
       }
     },
@@ -3584,6 +5370,4211 @@
         },
         "resolved_configuration": {
           "type": "string"
+        }
+      }
+    },
+    "RelationalDeleteRequest": {
+      "title": "Relational Delete Request",
+      "type": "object",
+      "required": [
+        "arguments",
+        "collection",
+        "relation"
+      ],
+      "properties": {
+        "collection": {
+          "description": "The name of the collection to delete from",
+          "type": "string"
+        },
+        "arguments": {
+          "description": "Values to be provided to any collection arguments",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Argument"
+          }
+        },
+        "relation": {
+          "description": "The relation that identifies which rows to delete",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Relation"
+            }
+          ]
+        }
+      }
+    },
+    "Relation": {
+      "title": "Relation",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "collection",
+            "columns",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "from"
+              ]
+            },
+            "collection": {
+              "type": "string"
+            },
+            "columns": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "arguments": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/RelationalLiteral"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "input",
+            "skip",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "paginate"
+              ]
+            },
+            "input": {
+              "$ref": "#/definitions/Relation"
+            },
+            "fetch": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "skip": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "exprs",
+            "input",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "project"
+              ]
+            },
+            "input": {
+              "$ref": "#/definitions/Relation"
+            },
+            "exprs": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RelationalExpression"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "input",
+            "predicate",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "filter"
+              ]
+            },
+            "input": {
+              "$ref": "#/definitions/Relation"
+            },
+            "predicate": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "exprs",
+            "input",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "sort"
+              ]
+            },
+            "input": {
+              "$ref": "#/definitions/Relation"
+            },
+            "exprs": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Sort"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "join_type",
+            "left",
+            "on",
+            "right",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "join"
+              ]
+            },
+            "left": {
+              "$ref": "#/definitions/Relation"
+            },
+            "right": {
+              "$ref": "#/definitions/Relation"
+            },
+            "on": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/JoinOn"
+              }
+            },
+            "join_type": {
+              "$ref": "#/definitions/JoinType"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "aggregates",
+            "group_by",
+            "input",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "aggregate"
+              ]
+            },
+            "input": {
+              "$ref": "#/definitions/Relation"
+            },
+            "group_by": {
+              "description": "Only non-empty if the 'relational_query.aggregate.group_by' capability is supported.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RelationalExpression"
+              }
+            },
+            "aggregates": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RelationalExpression"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "exprs",
+            "input",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "window"
+              ]
+            },
+            "input": {
+              "$ref": "#/definitions/Relation"
+            },
+            "exprs": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RelationalExpression"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "relations",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "union"
+              ]
+            },
+            "relations": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Relation"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "RelationalLiteral": {
+      "title": "RelationalLiteral",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "null"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "boolean"
+              ]
+            },
+            "value": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "description": "utf-8 encoded string.",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "string"
+              ]
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "signed 8bit int",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "int8"
+              ]
+            },
+            "value": {
+              "type": "integer",
+              "format": "int8"
+            }
+          }
+        },
+        {
+          "description": "signed 16bit int",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "int16"
+              ]
+            },
+            "value": {
+              "type": "integer",
+              "format": "int16"
+            }
+          }
+        },
+        {
+          "description": "signed 32bit int",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "int32"
+              ]
+            },
+            "value": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        },
+        {
+          "description": "signed 64bit int",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "int64"
+              ]
+            },
+            "value": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        },
+        {
+          "description": "unsigned 8bit int",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "uint8"
+              ]
+            },
+            "value": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          }
+        },
+        {
+          "description": "unsigned 16bit int",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "uint16"
+              ]
+            },
+            "value": {
+              "type": "integer",
+              "format": "uint16",
+              "minimum": 0.0
+            }
+          }
+        },
+        {
+          "description": "unsigned 32bit int",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "uint32"
+              ]
+            },
+            "value": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            }
+          }
+        },
+        {
+          "description": "unsigned 64bit int",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "uint64"
+              ]
+            },
+            "value": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        },
+        {
+          "description": "32bit float",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "float32"
+              ]
+            },
+            "value": {
+              "type": "number",
+              "format": "float"
+            }
+          }
+        },
+        {
+          "description": "64bit float",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "float64"
+              ]
+            },
+            "value": {
+              "type": "number",
+              "format": "double"
+            }
+          }
+        },
+        {
+          "description": "128-bit decimal",
+          "type": "object",
+          "required": [
+            "prec",
+            "scale",
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "decimal128"
+              ]
+            },
+            "value": {
+              "type": "integer",
+              "format": "int128"
+            },
+            "scale": {
+              "type": "integer",
+              "format": "int8"
+            },
+            "prec": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          }
+        },
+        {
+          "description": "256-bit decimal",
+          "type": "object",
+          "required": [
+            "prec",
+            "scale",
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "decimal256"
+              ]
+            },
+            "value": {
+              "type": "string"
+            },
+            "scale": {
+              "type": "integer",
+              "format": "int8"
+            },
+            "prec": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          }
+        },
+        {
+          "description": "Date stored as a signed 32bit int days since UNIX epoch 1970-01-01",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "date32"
+              ]
+            },
+            "value": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        },
+        {
+          "description": "Date stored as a signed 64bit int milliseconds since UNIX epoch 1970-01-01",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "date64"
+              ]
+            },
+            "value": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        },
+        {
+          "description": "Time stored as a signed 32bit int as seconds since midnight",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "time32_second"
+              ]
+            },
+            "value": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        },
+        {
+          "description": "Time stored as a signed 32bit int as milliseconds since midnight",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "time32_millisecond"
+              ]
+            },
+            "value": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        },
+        {
+          "description": "Time stored as a signed 64bit int as microseconds since midnight",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "time64_microsecond"
+              ]
+            },
+            "value": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        },
+        {
+          "description": "Time stored as a signed 64bit int as nanoseconds since midnight",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "time64_nanosecond"
+              ]
+            },
+            "value": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        },
+        {
+          "description": "Timestamp Second",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "timestamp_second"
+              ]
+            },
+            "value": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        },
+        {
+          "description": "Timestamp Milliseconds",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "timestamp_millisecond"
+              ]
+            },
+            "value": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        },
+        {
+          "description": "Timestamp Microseconds",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "timestamp_microsecond"
+              ]
+            },
+            "value": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        },
+        {
+          "description": "Timestamp Nanoseconds",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "timestamp_nanosecond"
+              ]
+            },
+            "value": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        },
+        {
+          "description": "Duration in seconds",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "duration_second"
+              ]
+            },
+            "value": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        },
+        {
+          "description": "Duration in milliseconds",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "duration_millisecond"
+              ]
+            },
+            "value": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        },
+        {
+          "description": "Duration in microseconds",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "duration_microsecond"
+              ]
+            },
+            "value": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        },
+        {
+          "description": "Duration in nanoseconds",
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "duration_nanosecond"
+              ]
+            },
+            "value": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        },
+        {
+          "description": "Interval represented as months, days, and nanoseconds",
+          "type": "object",
+          "required": [
+            "days",
+            "months",
+            "nanoseconds",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "interval"
+              ]
+            },
+            "months": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "days": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nanoseconds": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        }
+      ]
+    },
+    "RelationalExpression": {
+      "title": "RelationalExpression",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "literal",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "literal"
+              ]
+            },
+            "literal": {
+              "$ref": "#/definitions/RelationalLiteral"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "index",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "column"
+              ]
+            },
+            "index": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.conditional.case` * During filtering: `relational_query.filter.conditional.case` * During sorting:`relational_query.sort.expression.conditional.case` * During joining: `relational_query.join.expression.conditional.case` * During aggregation: `relational_query.aggregate.expression.conditional.case` * During windowing: `relational_query.window.expression.conditional.case`",
+          "type": "object",
+          "required": [
+            "type",
+            "when"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "case"
+              ]
+            },
+            "scrutinee": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/RelationalExpression"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "when": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/CaseWhen"
+              }
+            },
+            "default": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/RelationalExpression"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "left",
+            "right",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "and"
+              ]
+            },
+            "left": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "right": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "left",
+            "right",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "or"
+              ]
+            },
+            "left": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "right": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "not"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "left",
+            "right",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "eq"
+              ]
+            },
+            "left": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "right": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "left",
+            "right",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "not_eq"
+              ]
+            },
+            "left": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "right": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.comparison.is_distinct_from` * During filtering: `relational_query.filter.comparison.is_distinct_from` * During sorting:`relational_query.sort.expression.comparison.is_distinct_from` * During joining: `relational_query.join.expression.comparison.is_distinct_from` * During aggregation: `relational_query.aggregate.expression.comparison.is_distinct_from` * During windowing: `relational_query.window.expression.comparison.is_distinct_from`",
+          "type": "object",
+          "required": [
+            "left",
+            "right",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "is_distinct_from"
+              ]
+            },
+            "left": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "right": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.comparison.is_not_distinct_from` * During filtering: `relational_query.filter.comparison.is_not_distinct_from` * During sorting:`relational_query.sort.expression.comparison.is_not_distinct_from` * During joining: `relational_query.join.expression.comparison.is_not_distinct_from` * During aggregation: `relational_query.aggregate.expression.comparison.is_not_distinct_from` * During windowing: `relational_query.window.expression.comparison.is_not_distinct_from`",
+          "type": "object",
+          "required": [
+            "left",
+            "right",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "is_not_distinct_from"
+              ]
+            },
+            "left": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "right": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "left",
+            "right",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "lt"
+              ]
+            },
+            "left": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "right": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "left",
+            "right",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "lt_eq"
+              ]
+            },
+            "left": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "right": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "left",
+            "right",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "gt"
+              ]
+            },
+            "left": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "right": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "left",
+            "right",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "gt_eq"
+              ]
+            },
+            "left": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "right": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "is_not_null"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "is_null"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "is_true"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "is_false"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "is_not_true"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "is_not_false"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "expr",
+            "list",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "in"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "list": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RelationalExpression"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "expr",
+            "list",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "not_in"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "list": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RelationalExpression"
+              }
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.comparison.like` * During filtering: `relational_query.filter.comparison.like` * During sorting:`relational_query.sort.expression.comparison.like` * During joining: `relational_query.join.expression.comparison.like` * During aggregation: `relational_query.aggregate.expression.comparison.like` * During windowing: `relational_query.window.expression.comparison.like`",
+          "type": "object",
+          "required": [
+            "expr",
+            "pattern",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "like"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "pattern": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.comparison.like` * During filtering: `relational_query.filter.comparison.like` * During sorting:`relational_query.sort.expression.comparison.like` * During joining: `relational_query.join.expression.comparison.like` * During aggregation: `relational_query.aggregate.expression.comparison.like` * During windowing: `relational_query.window.expression.comparison.like`",
+          "type": "object",
+          "required": [
+            "expr",
+            "pattern",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "not_like"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "pattern": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.comparison.ilike` * During filtering: `relational_query.filter.comparison.ilike` * During sorting:`relational_query.sort.expression.comparison.ilike` * During joining: `relational_query.join.expression.comparison.ilike` * During aggregation: `relational_query.aggregate.expression.comparison.ilike` * During windowing: `relational_query.window.expression.comparison.ilike`",
+          "type": "object",
+          "required": [
+            "expr",
+            "pattern",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "i_like"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "pattern": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.comparison.ilike` * During filtering: `relational_query.filter.comparison.ilike` * During sorting:`relational_query.sort.expression.comparison.ilike` * During joining: `relational_query.join.expression.comparison.ilike` * During aggregation: `relational_query.aggregate.expression.comparison.ilike` * During windowing: `relational_query.window.expression.comparison.ilike`",
+          "type": "object",
+          "required": [
+            "expr",
+            "pattern",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "not_i_like"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "pattern": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.comparison.between` * During filtering: `relational_query.filter.comparison.between` * During sorting:`relational_query.sort.expression.comparison.between` * During joining: `relational_query.join.expression.comparison.between` * During aggregation: `relational_query.aggregate.expression.comparison.between` * During windowing: `relational_query.window.expression.comparison.between`",
+          "type": "object",
+          "required": [
+            "expr",
+            "high",
+            "low",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "between"
+              ]
+            },
+            "low": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "high": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.comparison.between` * During filtering: `relational_query.filter.comparison.between` * During sorting:`relational_query.sort.expression.comparison.between` * During joining: `relational_query.join.expression.comparison.between` * During aggregation: `relational_query.aggregate.expression.comparison.between` * During windowing: `relational_query.window.expression.comparison.between`",
+          "type": "object",
+          "required": [
+            "expr",
+            "high",
+            "low",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "not_between"
+              ]
+            },
+            "low": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "high": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.comparison.contains` * During filtering: `relational_query.filter.comparison.contains` * During sorting:`relational_query.sort.expression.comparison.contains` * During joining: `relational_query.join.expression.comparison.contains` * During aggregation: `relational_query.aggregate.expression.comparison.contains` * During windowing: `relational_query.window.expression.comparison.contains`",
+          "type": "object",
+          "required": [
+            "search_str",
+            "str",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "contains"
+              ]
+            },
+            "str": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "search_str": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.comparison.is_nan` * During filtering: `relational_query.filter.comparison.is_nan` * During sorting:`relational_query.sort.expression.comparison.is_nan` * During joining: `relational_query.join.expression.comparison.is_nan` * During aggregation: `relational_query.aggregate.expression.comparison.is_nan` * During windowing: `relational_query.window.expression.comparison.is_nan`",
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "is_na_n"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.comparison.is_zero` * During filtering: `relational_query.filter.comparison.is_zero` * During sorting:`relational_query.sort.expression.comparison.is_zero` * During joining: `relational_query.join.expression.comparison.is_zero` * During aggregation: `relational_query.aggregate.expression.comparison.is_zero` * During windowing: `relational_query.window.expression.comparison.is_zero`",
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "is_zero"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "left",
+            "right",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "plus"
+              ]
+            },
+            "left": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "right": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "left",
+            "right",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "minus"
+              ]
+            },
+            "left": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "right": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "left",
+            "right",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "multiply"
+              ]
+            },
+            "left": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "right": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "left",
+            "right",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "divide"
+              ]
+            },
+            "left": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "right": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "left",
+            "right",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "modulo"
+              ]
+            },
+            "left": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "right": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "negate"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "as_type",
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "cast"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "from_type": {
+              "description": "Optional for now, but will be required in the future",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/CastType"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "as_type": {
+              "$ref": "#/definitions/CastType"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "as_type",
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "try_cast"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "from_type": {
+              "description": "Optional for now, but will be required in the future",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/CastType"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "as_type": {
+              "$ref": "#/definitions/CastType"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.abs` * During filtering: `relational_query.filter.scalar.abs` * During sorting:`relational_query.sort.expression.scalar.abs` * During joining: `relational_query.join.expression.scalar.abs` * During aggregation: `relational_query.aggregate.expression.scalar.abs` * During windowing: `relational_query.window.expression.scalar.abs`",
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "abs"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.array_element` * During filtering: `relational_query.filter.scalar.array_element` * During sorting:`relational_query.sort.expression.scalar.array_element` * During joining: `relational_query.join.expression.scalar.array_element` * During aggregation: `relational_query.aggregate.expression.scalar.array_element` * During windowing: `relational_query.window.expression.scalar.array_element`",
+          "type": "object",
+          "required": [
+            "column",
+            "index",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "array_element"
+              ]
+            },
+            "column": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "index": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0.0
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.btrim` * During filtering: `relational_query.filter.scalar.btrim` * During sorting:`relational_query.sort.expression.scalar.btrim` * During joining: `relational_query.join.expression.scalar.btrim` * During aggregation: `relational_query.aggregate.expression.scalar.btrim` * During windowing: `relational_query.window.expression.scalar.btrim`",
+          "type": "object",
+          "required": [
+            "str",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "b_trim"
+              ]
+            },
+            "str": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "trim_str": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/RelationalExpression"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.ceil` * During filtering: `relational_query.filter.scalar.ceil` * During sorting:`relational_query.sort.expression.scalar.ceil` * During joining: `relational_query.join.expression.scalar.ceil` * During aggregation: `relational_query.aggregate.expression.scalar.ceil` * During windowing: `relational_query.window.expression.scalar.ceil`",
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "ceil"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.character_length` * During filtering: `relational_query.filter.scalar.character_length` * During sorting:`relational_query.sort.expression.scalar.character_length` * During joining: `relational_query.join.expression.scalar.character_length` * During aggregation: `relational_query.aggregate.expression.scalar.character_length` * During windowing: `relational_query.window.expression.scalar.character_length`",
+          "type": "object",
+          "required": [
+            "str",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "character_length"
+              ]
+            },
+            "str": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "exprs",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "coalesce"
+              ]
+            },
+            "exprs": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RelationalExpression"
+              }
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.concat` * During filtering: `relational_query.filter.scalar.concat` * During sorting:`relational_query.sort.expression.scalar.concat` * During joining: `relational_query.join.expression.scalar.concat` * During aggregation: `relational_query.aggregate.expression.scalar.concat` * During windowing: `relational_query.window.expression.scalar.concat`",
+          "type": "object",
+          "required": [
+            "exprs",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "concat"
+              ]
+            },
+            "exprs": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RelationalExpression"
+              }
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.cos` * During filtering: `relational_query.filter.scalar.cos` * During sorting:`relational_query.sort.expression.scalar.cos` * During joining: `relational_query.join.expression.scalar.cos` * During aggregation: `relational_query.aggregate.expression.scalar.cos` * During windowing: `relational_query.window.expression.scalar.cos`",
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "cos"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.current_date` * During filtering: `relational_query.filter.scalar.current_date` * During sorting:`relational_query.sort.expression.scalar.current_date` * During joining: `relational_query.join.expression.scalar.current_date` * During aggregation: `relational_query.aggregate.expression.scalar.current_date` * During windowing: `relational_query.window.expression.scalar.current_date`",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "current_date"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.current_time` * During filtering: `relational_query.filter.scalar.current_time` * During sorting:`relational_query.sort.expression.scalar.current_time` * During joining: `relational_query.join.expression.scalar.current_time` * During aggregation: `relational_query.aggregate.expression.scalar.current_time` * During windowing: `relational_query.window.expression.scalar.current_time`",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "current_time"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.current_timestamp` * During filtering: `relational_query.filter.scalar.current_timestamp` * During sorting:`relational_query.sort.expression.scalar.current_timestamp` * During joining: `relational_query.join.expression.scalar.current_timestamp` * During aggregation: `relational_query.aggregate.expression.scalar.current_timestamp` * During windowing: `relational_query.window.expression.scalar.current_timestamp`",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "current_timestamp"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.date_part` * During filtering: `relational_query.filter.scalar.date_part` * During sorting:`relational_query.sort.expression.scalar.date_part` * During joining: `relational_query.join.expression.scalar.date_part` * During aggregation: `relational_query.aggregate.expression.scalar.date_part` * During windowing: `relational_query.window.expression.scalar.date_part`",
+          "type": "object",
+          "required": [
+            "expr",
+            "part",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "date_part"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "part": {
+              "$ref": "#/definitions/DatePartUnit"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.date_trunc` * During filtering: `relational_query.filter.scalar.date_trunc` * During sorting:`relational_query.sort.expression.scalar.date_trunc` * During joining: `relational_query.join.expression.scalar.date_trunc` * During aggregation: `relational_query.aggregate.expression.scalar.date_trunc` * During windowing: `relational_query.window.expression.scalar.date_trunc`",
+          "type": "object",
+          "required": [
+            "expr",
+            "part",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "date_trunc"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "part": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.exp` * During filtering: `relational_query.filter.scalar.exp` * During sorting:`relational_query.sort.expression.scalar.exp` * During joining: `relational_query.join.expression.scalar.exp` * During aggregation: `relational_query.aggregate.expression.scalar.exp` * During windowing: `relational_query.window.expression.scalar.exp`",
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "exp"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.floor` * During filtering: `relational_query.filter.scalar.floor` * During sorting:`relational_query.sort.expression.scalar.floor` * During joining: `relational_query.join.expression.scalar.floor` * During aggregation: `relational_query.aggregate.expression.scalar.floor` * During windowing: `relational_query.window.expression.scalar.floor`",
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "floor"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.get_field` * During filtering: `relational_query.filter.scalar.get_field` * During sorting:`relational_query.sort.expression.scalar.get_field` * During joining: `relational_query.join.expression.scalar.get_field` * During aggregation: `relational_query.aggregate.expression.scalar.get_field` * During windowing: `relational_query.window.expression.scalar.get_field`",
+          "type": "object",
+          "required": [
+            "column",
+            "field",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "get_field"
+              ]
+            },
+            "column": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "field": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.greatest` * During filtering: `relational_query.filter.scalar.greatest` * During sorting:`relational_query.sort.expression.scalar.greatest` * During joining: `relational_query.join.expression.scalar.greatest` * During aggregation: `relational_query.aggregate.expression.scalar.greatest` * During windowing: `relational_query.window.expression.scalar.greatest`",
+          "type": "object",
+          "required": [
+            "exprs",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "greatest"
+              ]
+            },
+            "exprs": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RelationalExpression"
+              }
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.least` * During filtering: `relational_query.filter.scalar.least` * During sorting:`relational_query.sort.expression.scalar.least` * During joining: `relational_query.join.expression.scalar.least` * During aggregation: `relational_query.aggregate.expression.scalar.least` * During windowing: `relational_query.window.expression.scalar.least`",
+          "type": "object",
+          "required": [
+            "exprs",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "least"
+              ]
+            },
+            "exprs": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RelationalExpression"
+              }
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.left` * During filtering: `relational_query.filter.scalar.left` * During sorting:`relational_query.sort.expression.scalar.left` * During joining: `relational_query.join.expression.scalar.left` * During aggregation: `relational_query.aggregate.expression.scalar.left` * During windowing: `relational_query.window.expression.scalar.left`",
+          "type": "object",
+          "required": [
+            "n",
+            "str",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "left"
+              ]
+            },
+            "str": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "n": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.ln` * During filtering: `relational_query.filter.scalar.ln` * During sorting:`relational_query.sort.expression.scalar.ln` * During joining: `relational_query.join.expression.scalar.ln` * During aggregation: `relational_query.aggregate.expression.scalar.ln` * During windowing: `relational_query.window.expression.scalar.ln`",
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "ln"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.log` * During filtering: `relational_query.filter.scalar.log` * During sorting:`relational_query.sort.expression.scalar.log` * During joining: `relational_query.join.expression.scalar.log` * During aggregation: `relational_query.aggregate.expression.scalar.log` * During windowing: `relational_query.window.expression.scalar.log`",
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "log"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "base": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/RelationalExpression"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.log10` * During filtering: `relational_query.filter.scalar.log10` * During sorting:`relational_query.sort.expression.scalar.log10` * During joining: `relational_query.join.expression.scalar.log10` * During aggregation: `relational_query.aggregate.expression.scalar.log10` * During windowing: `relational_query.window.expression.scalar.log10`",
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "log10"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.log2` * During filtering: `relational_query.filter.scalar.log2` * During sorting:`relational_query.sort.expression.scalar.log2` * During joining: `relational_query.join.expression.scalar.log2` * During aggregation: `relational_query.aggregate.expression.scalar.log2` * During windowing: `relational_query.window.expression.scalar.log2`",
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "log2"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.lpad` * During filtering: `relational_query.filter.scalar.lpad` * During sorting:`relational_query.sort.expression.scalar.lpad` * During joining: `relational_query.join.expression.scalar.lpad` * During aggregation: `relational_query.aggregate.expression.scalar.lpad` * During windowing: `relational_query.window.expression.scalar.lpad`",
+          "type": "object",
+          "required": [
+            "n",
+            "str",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "l_pad"
+              ]
+            },
+            "str": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "n": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "padding_str": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/RelationalExpression"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.ltrim` * During filtering: `relational_query.filter.scalar.ltrim` * During sorting:`relational_query.sort.expression.scalar.ltrim` * During joining: `relational_query.join.expression.scalar.ltrim` * During aggregation: `relational_query.aggregate.expression.scalar.ltrim` * During windowing: `relational_query.window.expression.scalar.ltrim`",
+          "type": "object",
+          "required": [
+            "str",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "l_trim"
+              ]
+            },
+            "str": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "trim_str": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/RelationalExpression"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "expr1",
+            "expr2",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "null_if"
+              ]
+            },
+            "expr1": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "expr2": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.nvl` * During filtering: `relational_query.filter.scalar.nvl` * During sorting:`relational_query.sort.expression.scalar.nvl` * During joining: `relational_query.join.expression.scalar.nvl` * During aggregation: `relational_query.aggregate.expression.scalar.nvl` * During windowing: `relational_query.window.expression.scalar.nvl`",
+          "type": "object",
+          "required": [
+            "expr1",
+            "expr2",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "nvl"
+              ]
+            },
+            "expr1": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "expr2": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.power` * During filtering: `relational_query.filter.scalar.power` * During sorting:`relational_query.sort.expression.scalar.power` * During joining: `relational_query.join.expression.scalar.power` * During aggregation: `relational_query.aggregate.expression.scalar.power` * During windowing: `relational_query.window.expression.scalar.power`",
+          "type": "object",
+          "required": [
+            "base",
+            "exp",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "power"
+              ]
+            },
+            "base": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "exp": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.random` * During filtering: `relational_query.filter.scalar.random` * During sorting:`relational_query.sort.expression.scalar.random` * During joining: `relational_query.join.expression.scalar.random` * During aggregation: `relational_query.aggregate.expression.scalar.random` * During windowing: `relational_query.window.expression.scalar.random`",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "random"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.replace` * During filtering: `relational_query.filter.scalar.replace` * During sorting:`relational_query.sort.expression.scalar.replace` * During joining: `relational_query.join.expression.scalar.replace` * During aggregation: `relational_query.aggregate.expression.scalar.replace` * During windowing: `relational_query.window.expression.scalar.replace`",
+          "type": "object",
+          "required": [
+            "replacement",
+            "str",
+            "substr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "replace"
+              ]
+            },
+            "str": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "substr": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "replacement": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.reverse` * During filtering: `relational_query.filter.scalar.reverse` * During sorting:`relational_query.sort.expression.scalar.reverse` * During joining: `relational_query.join.expression.scalar.reverse` * During aggregation: `relational_query.aggregate.expression.scalar.reverse` * During windowing: `relational_query.window.expression.scalar.reverse`",
+          "type": "object",
+          "required": [
+            "str",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "reverse"
+              ]
+            },
+            "str": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.right` * During filtering: `relational_query.filter.scalar.right` * During sorting:`relational_query.sort.expression.scalar.right` * During joining: `relational_query.join.expression.scalar.right` * During aggregation: `relational_query.aggregate.expression.scalar.right` * During windowing: `relational_query.window.expression.scalar.right`",
+          "type": "object",
+          "required": [
+            "n",
+            "str",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "right"
+              ]
+            },
+            "str": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "n": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.round` * During filtering: `relational_query.filter.scalar.round` * During sorting:`relational_query.sort.expression.scalar.round` * During joining: `relational_query.join.expression.scalar.round` * During aggregation: `relational_query.aggregate.expression.scalar.round` * During windowing: `relational_query.window.expression.scalar.round`",
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "round"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "prec": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/RelationalExpression"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.rpad` * During filtering: `relational_query.filter.scalar.rpad` * During sorting:`relational_query.sort.expression.scalar.rpad` * During joining: `relational_query.join.expression.scalar.rpad` * During aggregation: `relational_query.aggregate.expression.scalar.rpad` * During windowing: `relational_query.window.expression.scalar.rpad`",
+          "type": "object",
+          "required": [
+            "n",
+            "str",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "r_pad"
+              ]
+            },
+            "str": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "n": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "padding_str": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/RelationalExpression"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.rtrim` * During filtering: `relational_query.filter.scalar.rtrim` * During sorting:`relational_query.sort.expression.scalar.rtrim` * During joining: `relational_query.join.expression.scalar.rtrim` * During aggregation: `relational_query.aggregate.expression.scalar.rtrim` * During windowing: `relational_query.window.expression.scalar.rtrim`",
+          "type": "object",
+          "required": [
+            "str",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "r_trim"
+              ]
+            },
+            "str": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "trim_str": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/RelationalExpression"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.sqrt` * During filtering: `relational_query.filter.scalar.sqrt` * During sorting:`relational_query.sort.expression.scalar.sqrt` * During joining: `relational_query.join.expression.scalar.sqrt` * During aggregation: `relational_query.aggregate.expression.scalar.sqrt` * During windowing: `relational_query.window.expression.scalar.sqrt`",
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "sqrt"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.strpos` * During filtering: `relational_query.filter.scalar.strpos` * During sorting:`relational_query.sort.expression.scalar.strpos` * During joining: `relational_query.join.expression.scalar.strpos` * During aggregation: `relational_query.aggregate.expression.scalar.strpos` * During windowing: `relational_query.window.expression.scalar.strpos`",
+          "type": "object",
+          "required": [
+            "str",
+            "substr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "str_pos"
+              ]
+            },
+            "str": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "substr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.substr` * During filtering: `relational_query.filter.scalar.substr` * During sorting:`relational_query.sort.expression.scalar.substr` * During joining: `relational_query.join.expression.scalar.substr` * During aggregation: `relational_query.aggregate.expression.scalar.substr` * During windowing: `relational_query.window.expression.scalar.substr`",
+          "type": "object",
+          "required": [
+            "start_pos",
+            "str",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "substr"
+              ]
+            },
+            "str": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "start_pos": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "len": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/RelationalExpression"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.substr_index` * During filtering: `relational_query.filter.scalar.substr_index` * During sorting:`relational_query.sort.expression.scalar.substr_index` * During joining: `relational_query.join.expression.scalar.substr_index` * During aggregation: `relational_query.aggregate.expression.scalar.substr_index` * During windowing: `relational_query.window.expression.scalar.substr_index`",
+          "type": "object",
+          "required": [
+            "count",
+            "delim",
+            "str",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "substr_index"
+              ]
+            },
+            "str": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "delim": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "count": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.tan` * During filtering: `relational_query.filter.scalar.tan` * During sorting:`relational_query.sort.expression.scalar.tan` * During joining: `relational_query.join.expression.scalar.tan` * During aggregation: `relational_query.aggregate.expression.scalar.tan` * During windowing: `relational_query.window.expression.scalar.tan`",
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "tan"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.to_date` * During filtering: `relational_query.filter.scalar.to_date` * During sorting:`relational_query.sort.expression.scalar.to_date` * During joining: `relational_query.join.expression.scalar.to_date` * During aggregation: `relational_query.aggregate.expression.scalar.to_date` * During windowing: `relational_query.window.expression.scalar.to_date`",
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "to_date"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.to_timestamp` * During filtering: `relational_query.filter.scalar.to_timestamp` * During sorting:`relational_query.sort.expression.scalar.to_timestamp` * During joining: `relational_query.join.expression.scalar.to_timestamp` * During aggregation: `relational_query.aggregate.expression.scalar.to_timestamp` * During windowing: `relational_query.window.expression.scalar.to_timestamp`",
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "to_timestamp"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.trunc` * During filtering: `relational_query.filter.scalar.trunc` * During sorting:`relational_query.sort.expression.scalar.trunc` * During joining: `relational_query.join.expression.scalar.trunc` * During aggregation: `relational_query.aggregate.expression.scalar.trunc` * During windowing: `relational_query.window.expression.scalar.trunc`",
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "trunc"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "prec": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/RelationalExpression"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.to_lower` * During filtering: `relational_query.filter.scalar.to_lower` * During sorting:`relational_query.sort.expression.scalar.to_lower` * During joining: `relational_query.join.expression.scalar.to_lower` * During aggregation: `relational_query.aggregate.expression.scalar.to_lower` * During windowing: `relational_query.window.expression.scalar.to_lower`",
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "to_lower"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.to_upper` * During filtering: `relational_query.filter.scalar.to_upper` * During sorting:`relational_query.sort.expression.scalar.to_upper` * During joining: `relational_query.join.expression.scalar.to_upper` * During aggregation: `relational_query.aggregate.expression.scalar.to_upper` * During windowing: `relational_query.window.expression.scalar.to_upper`",
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "to_upper"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.binary_concat` * During filtering: `relational_query.filter.scalar.binary_concat` * During sorting:`relational_query.sort.expression.scalar.binary_concat` * During joining: `relational_query.join.expression.scalar.binary_concat` * During aggregation: `relational_query.aggregate.expression.scalar.binary_concat` * During windowing: `relational_query.window.expression.scalar.binary_concat`",
+          "type": "object",
+          "required": [
+            "left",
+            "right",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "binary_concat"
+              ]
+            },
+            "left": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "right": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.json_contains` * During filtering: `relational_query.filter.scalar.json_contains` * During sorting:`relational_query.sort.expression.scalar.json_contains` * During joining: `relational_query.join.expression.scalar.json_contains` * During aggregation: `relational_query.aggregate.expression.scalar.json_contains` * During windowing: `relational_query.window.expression.scalar.json_contains`",
+          "type": "object",
+          "required": [
+            "json",
+            "keys",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "json_contains"
+              ]
+            },
+            "json": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "keys": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RelationalExpression"
+              }
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.json_get` * During filtering: `relational_query.filter.scalar.json_get` * During sorting:`relational_query.sort.expression.scalar.json_get` * During joining: `relational_query.join.expression.scalar.json_get` * During aggregation: `relational_query.aggregate.expression.scalar.json_get` * During windowing: `relational_query.window.expression.scalar.json_get`",
+          "type": "object",
+          "required": [
+            "json",
+            "keys",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "json_get"
+              ]
+            },
+            "json": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "keys": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RelationalExpression"
+              }
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.json_get_str` * During filtering: `relational_query.filter.scalar.json_get_str` * During sorting:`relational_query.sort.expression.scalar.json_get_str` * During joining: `relational_query.join.expression.scalar.json_get_str` * During aggregation: `relational_query.aggregate.expression.scalar.json_get_str` * During windowing: `relational_query.window.expression.scalar.json_get_str`",
+          "type": "object",
+          "required": [
+            "json",
+            "keys",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "json_get_str"
+              ]
+            },
+            "json": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "keys": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RelationalExpression"
+              }
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.json_get_int` * During filtering: `relational_query.filter.scalar.json_get_int` * During sorting:`relational_query.sort.expression.scalar.json_get_int` * During joining: `relational_query.join.expression.scalar.json_get_int` * During aggregation: `relational_query.aggregate.expression.scalar.json_get_int` * During windowing: `relational_query.window.expression.scalar.json_get_int`",
+          "type": "object",
+          "required": [
+            "json",
+            "keys",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "json_get_int"
+              ]
+            },
+            "json": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "keys": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RelationalExpression"
+              }
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.json_get_float` * During filtering: `relational_query.filter.scalar.json_get_float` * During sorting:`relational_query.sort.expression.scalar.json_get_float` * During joining: `relational_query.join.expression.scalar.json_get_float` * During aggregation: `relational_query.aggregate.expression.scalar.json_get_float` * During windowing: `relational_query.window.expression.scalar.json_get_float`",
+          "type": "object",
+          "required": [
+            "json",
+            "keys",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "json_get_float"
+              ]
+            },
+            "json": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "keys": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RelationalExpression"
+              }
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.json_get_bool` * During filtering: `relational_query.filter.scalar.json_get_bool` * During sorting:`relational_query.sort.expression.scalar.json_get_bool` * During joining: `relational_query.join.expression.scalar.json_get_bool` * During aggregation: `relational_query.aggregate.expression.scalar.json_get_bool` * During windowing: `relational_query.window.expression.scalar.json_get_bool`",
+          "type": "object",
+          "required": [
+            "json",
+            "keys",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "json_get_bool"
+              ]
+            },
+            "json": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "keys": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RelationalExpression"
+              }
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.json_get_json` * During filtering: `relational_query.filter.scalar.json_get_json` * During sorting:`relational_query.sort.expression.scalar.json_get_json` * During joining: `relational_query.join.expression.scalar.json_get_json` * During aggregation: `relational_query.aggregate.expression.scalar.json_get_json` * During windowing: `relational_query.window.expression.scalar.json_get_json`",
+          "type": "object",
+          "required": [
+            "json",
+            "keys",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "json_get_json"
+              ]
+            },
+            "json": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "keys": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RelationalExpression"
+              }
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.json_as_text` * During filtering: `relational_query.filter.scalar.json_as_text` * During sorting:`relational_query.sort.expression.scalar.json_as_text` * During joining: `relational_query.join.expression.scalar.json_as_text` * During aggregation: `relational_query.aggregate.expression.scalar.json_as_text` * During windowing: `relational_query.window.expression.scalar.json_as_text`",
+          "type": "object",
+          "required": [
+            "json",
+            "keys",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "json_as_text"
+              ]
+            },
+            "json": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "keys": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RelationalExpression"
+              }
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.scalar.json_length` * During filtering: `relational_query.filter.scalar.json_length` * During sorting:`relational_query.sort.expression.scalar.json_length` * During joining: `relational_query.join.expression.scalar.json_length` * During aggregation: `relational_query.aggregate.expression.scalar.json_length` * During windowing: `relational_query.window.expression.scalar.json_length`",
+          "type": "object",
+          "required": [
+            "json",
+            "keys",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "json_length"
+              ]
+            },
+            "json": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "keys": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RelationalExpression"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "average"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.aggregate.bool_and` * During filtering: `relational_query.filter.aggregate.bool_and` * During sorting:`relational_query.sort.expression.aggregate.bool_and` * During joining: `relational_query.join.expression.aggregate.bool_and` * During aggregation: `relational_query.aggregate.expression.aggregate.bool_and` * During windowing: `relational_query.window.expression.aggregate.bool_and`",
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "bool_and"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.aggregate.bool_or` * During filtering: `relational_query.filter.aggregate.bool_or` * During sorting:`relational_query.sort.expression.aggregate.bool_or` * During joining: `relational_query.join.expression.aggregate.bool_or` * During aggregation: `relational_query.aggregate.expression.aggregate.bool_or` * During windowing: `relational_query.window.expression.aggregate.bool_or`",
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "bool_or"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "distinct",
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "count"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "distinct": {
+              "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.aggregate.count.distinct` * During filtering: `relational_query.filter.aggregate.count.distinct` * During sorting:`relational_query.sort.expression.aggregate.count.distinct` * During joining: `relational_query.join.expression.aggregate.count.distinct` * During aggregation: `relational_query.aggregate.expression.aggregate.count.distinct` * During windowing: `relational_query.window.expression.aggregate.count.distinct`",
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.aggregate.first_value` * During filtering: `relational_query.filter.aggregate.first_value` * During sorting:`relational_query.sort.expression.aggregate.first_value` * During joining: `relational_query.join.expression.aggregate.first_value` * During aggregation: `relational_query.aggregate.expression.aggregate.first_value` * During windowing: `relational_query.window.expression.aggregate.first_value`",
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "first_value"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.aggregate.last_value` * During filtering: `relational_query.filter.aggregate.last_value` * During sorting:`relational_query.sort.expression.aggregate.last_value` * During joining: `relational_query.join.expression.aggregate.last_value` * During aggregation: `relational_query.aggregate.expression.aggregate.last_value` * During windowing: `relational_query.window.expression.aggregate.last_value`",
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "last_value"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "max"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.aggregate.median` * During filtering: `relational_query.filter.aggregate.median` * During sorting:`relational_query.sort.expression.aggregate.median` * During joining: `relational_query.join.expression.aggregate.median` * During aggregation: `relational_query.aggregate.expression.aggregate.median` * During windowing: `relational_query.window.expression.aggregate.median`",
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "median"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "min"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.aggregate.string_agg` * During filtering: `relational_query.filter.aggregate.string_agg` * During sorting:`relational_query.sort.expression.aggregate.string_agg` * During joining: `relational_query.join.expression.aggregate.string_agg` * During aggregation: `relational_query.aggregate.expression.aggregate.string_agg` * During windowing: `relational_query.window.expression.aggregate.string_agg`",
+          "type": "object",
+          "required": [
+            "distinct",
+            "expr",
+            "separator",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "string_agg"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "separator": {
+              "type": "string"
+            },
+            "distinct": {
+              "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.aggregate.string_agg.distinct` * During filtering: `relational_query.filter.aggregate.string_agg.distinct` * During sorting:`relational_query.sort.expression.aggregate.string_agg.distinct` * During joining: `relational_query.join.expression.aggregate.string_agg.distinct` * During aggregation: `relational_query.aggregate.expression.aggregate.string_agg.distinct` * During windowing: `relational_query.window.expression.aggregate.string_agg.distinct`",
+              "type": "boolean"
+            },
+            "order_by": {
+              "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.aggregate.string_agg.order_by` * During filtering: `relational_query.filter.aggregate.string_agg.order_by` * During sorting:`relational_query.sort.expression.aggregate.string_agg.order_by` * During joining: `relational_query.join.expression.aggregate.string_agg.order_by` * During aggregation: `relational_query.aggregate.expression.aggregate.string_agg.order_by` * During windowing: `relational_query.window.expression.aggregate.string_agg.order_by`",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "$ref": "#/definitions/Sort"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "sum"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.aggregate.var` * During filtering: `relational_query.filter.aggregate.var` * During sorting:`relational_query.sort.expression.aggregate.var` * During joining: `relational_query.join.expression.aggregate.var` * During aggregation: `relational_query.aggregate.expression.aggregate.var` * During windowing: `relational_query.window.expression.aggregate.var`",
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "var"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.aggregate.stddev` * During filtering: `relational_query.filter.aggregate.stddev` * During sorting:`relational_query.sort.expression.aggregate.stddev` * During joining: `relational_query.join.expression.aggregate.stddev` * During aggregation: `relational_query.aggregate.expression.aggregate.stddev` * During windowing: `relational_query.window.expression.aggregate.stddev`",
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "stddev"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.aggregate.stddev_pop` * During filtering: `relational_query.filter.aggregate.stddev_pop` * During sorting:`relational_query.sort.expression.aggregate.stddev_pop` * During joining: `relational_query.join.expression.aggregate.stddev_pop` * During aggregation: `relational_query.aggregate.expression.aggregate.stddev_pop` * During windowing: `relational_query.window.expression.aggregate.stddev_pop`",
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "stddev_pop"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.aggregate.approx_percentile_cont` * During filtering: `relational_query.filter.aggregate.approx_percentile_cont` * During sorting:`relational_query.sort.expression.aggregate.approx_percentile_cont` * During joining: `relational_query.join.expression.aggregate.approx_percentile_cont` * During aggregation: `relational_query.aggregate.expression.aggregate.approx_percentile_cont` * During windowing: `relational_query.window.expression.aggregate.approx_percentile_cont`",
+          "type": "object",
+          "required": [
+            "expr",
+            "percentile",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "approx_percentile_cont"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "percentile": {
+              "type": "number",
+              "format": "double"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.aggregate.array_agg` * During filtering: `relational_query.filter.aggregate.array_agg` * During sorting:`relational_query.sort.expression.aggregate.array_agg` * During joining: `relational_query.join.expression.aggregate.array_agg` * During aggregation: `relational_query.aggregate.expression.aggregate.array_agg` * During windowing: `relational_query.window.expression.aggregate.array_agg`",
+          "type": "object",
+          "required": [
+            "distinct",
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "array_agg"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            },
+            "distinct": {
+              "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.aggregate.array_agg.distinct` * During filtering: `relational_query.filter.aggregate.array_agg.distinct` * During sorting:`relational_query.sort.expression.aggregate.array_agg.distinct` * During joining: `relational_query.join.expression.aggregate.array_agg.distinct` * During aggregation: `relational_query.aggregate.expression.aggregate.array_agg.distinct` * During windowing: `relational_query.window.expression.aggregate.array_agg.distinct`",
+              "type": "boolean"
+            },
+            "order_by": {
+              "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.aggregate.array_agg.order_by` * During filtering: `relational_query.filter.aggregate.array_agg.order_by` * During sorting:`relational_query.sort.expression.aggregate.array_agg.order_by` * During joining: `relational_query.join.expression.aggregate.array_agg.order_by` * During aggregation: `relational_query.aggregate.expression.aggregate.array_agg.order_by` * During windowing: `relational_query.window.expression.aggregate.array_agg.order_by`",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "$ref": "#/definitions/Sort"
+              }
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.aggregate.approx_distinct` * During filtering: `relational_query.filter.aggregate.approx_distinct` * During sorting:`relational_query.sort.expression.aggregate.approx_distinct` * During joining: `relational_query.join.expression.aggregate.approx_distinct` * During aggregation: `relational_query.aggregate.expression.aggregate.approx_distinct` * During windowing: `relational_query.window.expression.aggregate.approx_distinct`",
+          "type": "object",
+          "required": [
+            "expr",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "approx_distinct"
+              ]
+            },
+            "expr": {
+              "$ref": "#/definitions/RelationalExpression"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.window.row_number` * During filtering: `relational_query.filter.window.row_number` * During sorting:`relational_query.sort.expression.window.row_number` * During joining: `relational_query.join.expression.window.row_number` * During aggregation: `relational_query.window.row_number` * During windowing: `relational_query.window.expression.window.row_number`",
+          "type": "object",
+          "required": [
+            "order_by",
+            "partition_by",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "row_number"
+              ]
+            },
+            "order_by": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Sort"
+              }
+            },
+            "partition_by": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RelationalExpression"
+              }
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.window.dense_rank` * During filtering: `relational_query.filter.window.dense_rank` * During sorting:`relational_query.sort.expression.window.dense_rank` * During joining: `relational_query.join.expression.window.dense_rank` * During aggregation: `relational_query.window.dense_rank` * During windowing: `relational_query.window.expression.window.dense_rank`",
+          "type": "object",
+          "required": [
+            "order_by",
+            "partition_by",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "dense_rank"
+              ]
+            },
+            "order_by": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Sort"
+              }
+            },
+            "partition_by": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RelationalExpression"
+              }
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.window.ntile` * During filtering: `relational_query.filter.window.ntile` * During sorting:`relational_query.sort.expression.window.ntile` * During joining: `relational_query.join.expression.window.ntile` * During aggregation: `relational_query.window.ntile` * During windowing: `relational_query.window.expression.window.ntile`",
+          "type": "object",
+          "required": [
+            "n",
+            "order_by",
+            "partition_by",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "n_tile"
+              ]
+            },
+            "order_by": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Sort"
+              }
+            },
+            "partition_by": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RelationalExpression"
+              }
+            },
+            "n": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.window.rank` * During filtering: `relational_query.filter.window.rank` * During sorting:`relational_query.sort.expression.window.rank` * During joining: `relational_query.join.expression.window.rank` * During aggregation: `relational_query.window.rank` * During windowing: `relational_query.window.expression.window.rank`",
+          "type": "object",
+          "required": [
+            "order_by",
+            "partition_by",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "rank"
+              ]
+            },
+            "order_by": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Sort"
+              }
+            },
+            "partition_by": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RelationalExpression"
+              }
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.window.cume_dist` * During filtering: `relational_query.filter.window.cume_dist` * During sorting:`relational_query.sort.expression.window.cume_dist` * During joining: `relational_query.join.expression.window.cume_dist` * During aggregation: `relational_query.window.cume_dist` * During windowing: `relational_query.window.expression.window.cume_dist`",
+          "type": "object",
+          "required": [
+            "order_by",
+            "partition_by",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "cume_dist"
+              ]
+            },
+            "order_by": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Sort"
+              }
+            },
+            "partition_by": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RelationalExpression"
+              }
+            }
+          }
+        },
+        {
+          "description": "Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.window.percent_rank` * During filtering: `relational_query.filter.window.percent_rank` * During sorting:`relational_query.sort.expression.window.percent_rank` * During joining: `relational_query.join.expression.window.percent_rank` * During aggregation: `relational_query.window.percent_rank` * During windowing: `relational_query.window.expression.window.percent_rank`",
+          "type": "object",
+          "required": [
+            "order_by",
+            "partition_by",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "percent_rank"
+              ]
+            },
+            "order_by": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Sort"
+              }
+            },
+            "partition_by": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RelationalExpression"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "CaseWhen": {
+      "title": "CaseWhen",
+      "type": "object",
+      "required": [
+        "then",
+        "when"
+      ],
+      "properties": {
+        "when": {
+          "$ref": "#/definitions/RelationalExpression"
+        },
+        "then": {
+          "$ref": "#/definitions/RelationalExpression"
+        }
+      }
+    },
+    "CastType": {
+      "title": "CastType",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "boolean"
+              ]
+            }
+          }
+        },
+        {
+          "description": "utf-8 encoded string.",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "utf8"
+              ]
+            }
+          }
+        },
+        {
+          "description": "signed 8bit int",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "int8"
+              ]
+            }
+          }
+        },
+        {
+          "description": "signed 16bit int",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "int16"
+              ]
+            }
+          }
+        },
+        {
+          "description": "signed 32bit int",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "int32"
+              ]
+            }
+          }
+        },
+        {
+          "description": "signed 64bit int",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "int64"
+              ]
+            }
+          }
+        },
+        {
+          "description": "unsigned 8bit int",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "uint8"
+              ]
+            }
+          }
+        },
+        {
+          "description": "unsigned 16bit int",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "uint16"
+              ]
+            }
+          }
+        },
+        {
+          "description": "unsigned 32bit int",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "uint32"
+              ]
+            }
+          }
+        },
+        {
+          "description": "unsigned 64bit int",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "uint64"
+              ]
+            }
+          }
+        },
+        {
+          "description": "32bit float",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "float32"
+              ]
+            }
+          }
+        },
+        {
+          "description": "64bit float",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "float64"
+              ]
+            }
+          }
+        },
+        {
+          "description": "128-bit decimal",
+          "type": "object",
+          "required": [
+            "prec",
+            "scale",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "decimal128"
+              ]
+            },
+            "scale": {
+              "type": "integer",
+              "format": "int8"
+            },
+            "prec": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          }
+        },
+        {
+          "description": "256-bit decimal",
+          "type": "object",
+          "required": [
+            "prec",
+            "scale",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "decimal256"
+              ]
+            },
+            "scale": {
+              "type": "integer",
+              "format": "int8"
+            },
+            "prec": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          }
+        },
+        {
+          "description": "date",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "date"
+              ]
+            }
+          }
+        },
+        {
+          "description": "time",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "time"
+              ]
+            }
+          }
+        },
+        {
+          "description": "ISO 8601 timestamp",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "timestamp"
+              ]
+            }
+          }
+        },
+        {
+          "description": "duration",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "duration"
+              ]
+            }
+          }
+        },
+        {
+          "description": "interval",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "interval"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "DatePartUnit": {
+      "title": "DatePartUnit",
+      "type": "string",
+      "enum": [
+        "year",
+        "quarter",
+        "month",
+        "week",
+        "day_of_week",
+        "day_of_year",
+        "day",
+        "hour",
+        "minute",
+        "second",
+        "microsecond",
+        "millisecond",
+        "nanosecond",
+        "epoch"
+      ]
+    },
+    "Sort": {
+      "title": "Sort",
+      "type": "object",
+      "required": [
+        "direction",
+        "expr",
+        "nulls_sort"
+      ],
+      "properties": {
+        "expr": {
+          "$ref": "#/definitions/RelationalExpression"
+        },
+        "direction": {
+          "$ref": "#/definitions/OrderDirection"
+        },
+        "nulls_sort": {
+          "$ref": "#/definitions/NullsSort"
+        }
+      }
+    },
+    "NullsSort": {
+      "title": "Nulls Sort",
+      "type": "string",
+      "enum": [
+        "nulls_first",
+        "nulls_last"
+      ]
+    },
+    "JoinOn": {
+      "title": "JoinOn",
+      "type": "object",
+      "required": [
+        "left",
+        "right"
+      ],
+      "properties": {
+        "left": {
+          "$ref": "#/definitions/RelationalExpression"
+        },
+        "right": {
+          "$ref": "#/definitions/RelationalExpression"
+        }
+      }
+    },
+    "JoinType": {
+      "title": "JoinType",
+      "oneOf": [
+        {
+          "description": "Only used when the capability `relational_query.join.join_types.left` is supported.",
+          "type": "string",
+          "enum": [
+            "left"
+          ]
+        },
+        {
+          "description": "Only used when the capability `relational_query.join.join_types.right` is supported.",
+          "type": "string",
+          "enum": [
+            "right"
+          ]
+        },
+        {
+          "description": "Only used when the capability `relational_query.join.join_types.inner` is supported.",
+          "type": "string",
+          "enum": [
+            "inner"
+          ]
+        },
+        {
+          "description": "Only used when the capability `relational_query.join.join_types.full` is supported.",
+          "type": "string",
+          "enum": [
+            "full"
+          ]
+        },
+        {
+          "description": "Only used when the capability `relational_query.join.join_types.left_anti` is supported.",
+          "type": "string",
+          "enum": [
+            "left_anti"
+          ]
+        },
+        {
+          "description": "Only used when the capability `relational_query.join.join_types.left_semi` is supported.",
+          "type": "string",
+          "enum": [
+            "left_semi"
+          ]
+        },
+        {
+          "description": "Only used when the capability `relational_query.join.join_types.right_anti` is supported.",
+          "type": "string",
+          "enum": [
+            "right_anti"
+          ]
+        },
+        {
+          "description": "Only used when the capability `relational_query.join.join_types.right_semi` is supported.",
+          "type": "string",
+          "enum": [
+            "right_semi"
+          ]
+        }
+      ]
+    },
+    "RelationalDeleteResponse": {
+      "title": "Relational Delete Response",
+      "type": "object",
+      "required": [
+        "affected_rows"
+      ],
+      "properties": {
+        "affected_rows": {
+          "description": "The number of rows that were deleted",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      }
+    },
+    "RelationalInsertRequest": {
+      "title": "Relational Insert Request",
+      "type": "object",
+      "required": [
+        "arguments",
+        "collection",
+        "columns",
+        "rows"
+      ],
+      "properties": {
+        "collection": {
+          "description": "The name of the collection to insert into",
+          "type": "string"
+        },
+        "arguments": {
+          "description": "Values to be provided to any collection arguments",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Argument"
+          }
+        },
+        "columns": {
+          "description": "The columns to insert values for",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "rows": {
+          "description": "The rows to insert, each row containing values for the specified columns",
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": true
+          }
+        }
+      }
+    },
+    "RelationalInsertResponse": {
+      "title": "Relational Insert Response",
+      "type": "object",
+      "required": [
+        "affected_rows"
+      ],
+      "properties": {
+        "affected_rows": {
+          "description": "The number of rows that were inserted",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      }
+    },
+    "RelationalQuery": {
+      "title": "RelationalQuery",
+      "type": "object",
+      "required": [
+        "root_relation"
+      ],
+      "properties": {
+        "root_relation": {
+          "$ref": "#/definitions/Relation"
+        },
+        "request_arguments": {
+          "description": "Values to be provided to request-level arguments.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        }
+      }
+    },
+    "RelationalQueryResponse": {
+      "title": "RelationalQueryResponse",
+      "type": "object",
+      "required": [
+        "rows"
+      ],
+      "properties": {
+        "rows": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": true
+          }
+        }
+      }
+    },
+    "RelationalUpdateRequest": {
+      "title": "Relational Update Request",
+      "type": "object",
+      "required": [
+        "arguments",
+        "collection",
+        "relation"
+      ],
+      "properties": {
+        "collection": {
+          "description": "The name of the collection to update",
+          "type": "string"
+        },
+        "arguments": {
+          "description": "Values to be provided to any collection arguments",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Argument"
+          }
+        },
+        "relation": {
+          "description": "The relation that identifies which rows to update",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Relation"
+            }
+          ]
+        }
+      }
+    },
+    "RelationalUpdateResponse": {
+      "title": "Relational Update Response",
+      "type": "object",
+      "required": [
+        "affected_rows"
+      ],
+      "properties": {
+        "affected_rows": {
+          "description": "The number of rows that were updated",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
         }
       }
     }

--- a/src/schema/schema.generated.ts
+++ b/src/schema/schema.generated.ts
@@ -196,6 +196,13 @@ export type ExtractionFunctionDefinition =
       result_type: string;
     }
   | {
+      type: "millisecond";
+      /**
+       * The result type, which must be a defined scalar type in the schema response.
+       */
+      result_type: string;
+    }
+  | {
       type: "second";
       /**
        * The result type, which must be a defined scalar type in the schema response.
@@ -663,6 +670,834 @@ export type MutationOperationResults = {
   type: "procedure";
   result: unknown;
 };
+export type Relation =
+  | {
+      type: "from";
+      collection: string;
+      columns: string[];
+      arguments?: {
+        [k: string]: RelationalLiteral;
+      };
+    }
+  | {
+      type: "paginate";
+      input: Relation;
+      fetch?: number | null;
+      skip: number;
+    }
+  | {
+      type: "project";
+      input: Relation;
+      exprs: RelationalExpression[];
+    }
+  | {
+      type: "filter";
+      input: Relation;
+      predicate: RelationalExpression;
+    }
+  | {
+      type: "sort";
+      input: Relation;
+      exprs: Sort[];
+    }
+  | {
+      type: "join";
+      left: Relation;
+      right: Relation;
+      on: JoinOn[];
+      join_type: JoinType;
+    }
+  | {
+      type: "aggregate";
+      input: Relation;
+      /**
+       * Only non-empty if the 'relational_query.aggregate.group_by' capability is supported.
+       */
+      group_by: RelationalExpression[];
+      aggregates: RelationalExpression[];
+    }
+  | {
+      type: "window";
+      input: Relation;
+      exprs: RelationalExpression[];
+    }
+  | {
+      type: "union";
+      relations: Relation[];
+    };
+export type RelationalLiteral =
+  | {
+      type: "null";
+    }
+  | {
+      type: "boolean";
+      value: boolean;
+    }
+  | {
+      type: "string";
+      value: string;
+    }
+  | {
+      type: "int8";
+      value: number;
+    }
+  | {
+      type: "int16";
+      value: number;
+    }
+  | {
+      type: "int32";
+      value: number;
+    }
+  | {
+      type: "int64";
+      value: number;
+    }
+  | {
+      type: "uint8";
+      value: number;
+    }
+  | {
+      type: "uint16";
+      value: number;
+    }
+  | {
+      type: "uint32";
+      value: number;
+    }
+  | {
+      type: "uint64";
+      value: number;
+    }
+  | {
+      type: "float32";
+      value: number;
+    }
+  | {
+      type: "float64";
+      value: number;
+    }
+  | {
+      type: "decimal128";
+      value: number;
+      scale: number;
+      prec: number;
+    }
+  | {
+      type: "decimal256";
+      value: string;
+      scale: number;
+      prec: number;
+    }
+  | {
+      type: "date32";
+      value: number;
+    }
+  | {
+      type: "date64";
+      value: number;
+    }
+  | {
+      type: "time32_second";
+      value: number;
+    }
+  | {
+      type: "time32_millisecond";
+      value: number;
+    }
+  | {
+      type: "time64_microsecond";
+      value: number;
+    }
+  | {
+      type: "time64_nanosecond";
+      value: number;
+    }
+  | {
+      type: "timestamp_second";
+      value: number;
+    }
+  | {
+      type: "timestamp_millisecond";
+      value: number;
+    }
+  | {
+      type: "timestamp_microsecond";
+      value: number;
+    }
+  | {
+      type: "timestamp_nanosecond";
+      value: number;
+    }
+  | {
+      type: "duration_second";
+      value: number;
+    }
+  | {
+      type: "duration_millisecond";
+      value: number;
+    }
+  | {
+      type: "duration_microsecond";
+      value: number;
+    }
+  | {
+      type: "duration_nanosecond";
+      value: number;
+    }
+  | {
+      type: "interval";
+      months: number;
+      days: number;
+      nanoseconds: number;
+    };
+export type RelationalExpression =
+  | {
+      type: "literal";
+      literal: RelationalLiteral;
+    }
+  | {
+      type: "column";
+      index: number;
+    }
+  | {
+      type: "case";
+      scrutinee?: RelationalExpression | null;
+      when: CaseWhen[];
+      default?: RelationalExpression | null;
+    }
+  | {
+      type: "and";
+      left: RelationalExpression;
+      right: RelationalExpression;
+    }
+  | {
+      type: "or";
+      left: RelationalExpression;
+      right: RelationalExpression;
+    }
+  | {
+      type: "not";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "eq";
+      left: RelationalExpression;
+      right: RelationalExpression;
+    }
+  | {
+      type: "not_eq";
+      left: RelationalExpression;
+      right: RelationalExpression;
+    }
+  | {
+      type: "is_distinct_from";
+      left: RelationalExpression;
+      right: RelationalExpression;
+    }
+  | {
+      type: "is_not_distinct_from";
+      left: RelationalExpression;
+      right: RelationalExpression;
+    }
+  | {
+      type: "lt";
+      left: RelationalExpression;
+      right: RelationalExpression;
+    }
+  | {
+      type: "lt_eq";
+      left: RelationalExpression;
+      right: RelationalExpression;
+    }
+  | {
+      type: "gt";
+      left: RelationalExpression;
+      right: RelationalExpression;
+    }
+  | {
+      type: "gt_eq";
+      left: RelationalExpression;
+      right: RelationalExpression;
+    }
+  | {
+      type: "is_not_null";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "is_null";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "is_true";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "is_false";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "is_not_true";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "is_not_false";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "in";
+      expr: RelationalExpression;
+      list: RelationalExpression[];
+    }
+  | {
+      type: "not_in";
+      expr: RelationalExpression;
+      list: RelationalExpression[];
+    }
+  | {
+      type: "like";
+      expr: RelationalExpression;
+      pattern: RelationalExpression;
+    }
+  | {
+      type: "not_like";
+      expr: RelationalExpression;
+      pattern: RelationalExpression;
+    }
+  | {
+      type: "i_like";
+      expr: RelationalExpression;
+      pattern: RelationalExpression;
+    }
+  | {
+      type: "not_i_like";
+      expr: RelationalExpression;
+      pattern: RelationalExpression;
+    }
+  | {
+      type: "between";
+      low: RelationalExpression;
+      expr: RelationalExpression;
+      high: RelationalExpression;
+    }
+  | {
+      type: "not_between";
+      low: RelationalExpression;
+      expr: RelationalExpression;
+      high: RelationalExpression;
+    }
+  | {
+      type: "contains";
+      str: RelationalExpression;
+      search_str: RelationalExpression;
+    }
+  | {
+      type: "is_na_n";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "is_zero";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "plus";
+      left: RelationalExpression;
+      right: RelationalExpression;
+    }
+  | {
+      type: "minus";
+      left: RelationalExpression;
+      right: RelationalExpression;
+    }
+  | {
+      type: "multiply";
+      left: RelationalExpression;
+      right: RelationalExpression;
+    }
+  | {
+      type: "divide";
+      left: RelationalExpression;
+      right: RelationalExpression;
+    }
+  | {
+      type: "modulo";
+      left: RelationalExpression;
+      right: RelationalExpression;
+    }
+  | {
+      type: "negate";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "cast";
+      expr: RelationalExpression;
+      /**
+       * Optional for now, but will be required in the future
+       */
+      from_type?: CastType | null;
+      as_type: CastType;
+    }
+  | {
+      type: "try_cast";
+      expr: RelationalExpression;
+      /**
+       * Optional for now, but will be required in the future
+       */
+      from_type?: CastType | null;
+      as_type: CastType;
+    }
+  | {
+      type: "abs";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "array_element";
+      column: RelationalExpression;
+      index: number;
+    }
+  | {
+      type: "b_trim";
+      str: RelationalExpression;
+      trim_str?: RelationalExpression | null;
+    }
+  | {
+      type: "ceil";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "character_length";
+      str: RelationalExpression;
+    }
+  | {
+      type: "coalesce";
+      exprs: RelationalExpression[];
+    }
+  | {
+      type: "concat";
+      exprs: RelationalExpression[];
+    }
+  | {
+      type: "cos";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "current_date";
+    }
+  | {
+      type: "current_time";
+    }
+  | {
+      type: "current_timestamp";
+    }
+  | {
+      type: "date_part";
+      expr: RelationalExpression;
+      part: DatePartUnit;
+    }
+  | {
+      type: "date_trunc";
+      expr: RelationalExpression;
+      part: RelationalExpression;
+    }
+  | {
+      type: "exp";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "floor";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "get_field";
+      column: RelationalExpression;
+      field: string;
+    }
+  | {
+      type: "greatest";
+      exprs: RelationalExpression[];
+    }
+  | {
+      type: "least";
+      exprs: RelationalExpression[];
+    }
+  | {
+      type: "left";
+      str: RelationalExpression;
+      n: RelationalExpression;
+    }
+  | {
+      type: "ln";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "log";
+      expr: RelationalExpression;
+      base?: RelationalExpression | null;
+    }
+  | {
+      type: "log10";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "log2";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "l_pad";
+      str: RelationalExpression;
+      n: RelationalExpression;
+      padding_str?: RelationalExpression | null;
+    }
+  | {
+      type: "l_trim";
+      str: RelationalExpression;
+      trim_str?: RelationalExpression | null;
+    }
+  | {
+      type: "null_if";
+      expr1: RelationalExpression;
+      expr2: RelationalExpression;
+    }
+  | {
+      type: "nvl";
+      expr1: RelationalExpression;
+      expr2: RelationalExpression;
+    }
+  | {
+      type: "power";
+      base: RelationalExpression;
+      exp: RelationalExpression;
+    }
+  | {
+      type: "random";
+    }
+  | {
+      type: "replace";
+      str: RelationalExpression;
+      substr: RelationalExpression;
+      replacement: RelationalExpression;
+    }
+  | {
+      type: "reverse";
+      str: RelationalExpression;
+    }
+  | {
+      type: "right";
+      str: RelationalExpression;
+      n: RelationalExpression;
+    }
+  | {
+      type: "round";
+      expr: RelationalExpression;
+      prec?: RelationalExpression | null;
+    }
+  | {
+      type: "r_pad";
+      str: RelationalExpression;
+      n: RelationalExpression;
+      padding_str?: RelationalExpression | null;
+    }
+  | {
+      type: "r_trim";
+      str: RelationalExpression;
+      trim_str?: RelationalExpression | null;
+    }
+  | {
+      type: "sqrt";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "str_pos";
+      str: RelationalExpression;
+      substr: RelationalExpression;
+    }
+  | {
+      type: "substr";
+      str: RelationalExpression;
+      start_pos: RelationalExpression;
+      len?: RelationalExpression | null;
+    }
+  | {
+      type: "substr_index";
+      str: RelationalExpression;
+      delim: RelationalExpression;
+      count: RelationalExpression;
+    }
+  | {
+      type: "tan";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "to_date";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "to_timestamp";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "trunc";
+      expr: RelationalExpression;
+      prec?: RelationalExpression | null;
+    }
+  | {
+      type: "to_lower";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "to_upper";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "binary_concat";
+      left: RelationalExpression;
+      right: RelationalExpression;
+    }
+  | {
+      type: "json_contains";
+      json: RelationalExpression;
+      keys: RelationalExpression[];
+    }
+  | {
+      type: "json_get";
+      json: RelationalExpression;
+      keys: RelationalExpression[];
+    }
+  | {
+      type: "json_get_str";
+      json: RelationalExpression;
+      keys: RelationalExpression[];
+    }
+  | {
+      type: "json_get_int";
+      json: RelationalExpression;
+      keys: RelationalExpression[];
+    }
+  | {
+      type: "json_get_float";
+      json: RelationalExpression;
+      keys: RelationalExpression[];
+    }
+  | {
+      type: "json_get_bool";
+      json: RelationalExpression;
+      keys: RelationalExpression[];
+    }
+  | {
+      type: "json_get_json";
+      json: RelationalExpression;
+      keys: RelationalExpression[];
+    }
+  | {
+      type: "json_as_text";
+      json: RelationalExpression;
+      keys: RelationalExpression[];
+    }
+  | {
+      type: "json_length";
+      json: RelationalExpression;
+      keys: RelationalExpression[];
+    }
+  | {
+      type: "average";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "bool_and";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "bool_or";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "count";
+      expr: RelationalExpression;
+      /**
+       * Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.aggregate.count.distinct` * During filtering: `relational_query.filter.aggregate.count.distinct` * During sorting:`relational_query.sort.expression.aggregate.count.distinct` * During joining: `relational_query.join.expression.aggregate.count.distinct` * During aggregation: `relational_query.aggregate.expression.aggregate.count.distinct` * During windowing: `relational_query.window.expression.aggregate.count.distinct`
+       */
+      distinct: boolean;
+    }
+  | {
+      type: "first_value";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "last_value";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "max";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "median";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "min";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "string_agg";
+      expr: RelationalExpression;
+      separator: string;
+      /**
+       * Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.aggregate.string_agg.distinct` * During filtering: `relational_query.filter.aggregate.string_agg.distinct` * During sorting:`relational_query.sort.expression.aggregate.string_agg.distinct` * During joining: `relational_query.join.expression.aggregate.string_agg.distinct` * During aggregation: `relational_query.aggregate.expression.aggregate.string_agg.distinct` * During windowing: `relational_query.window.expression.aggregate.string_agg.distinct`
+       */
+      distinct: boolean;
+      /**
+       * Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.aggregate.string_agg.order_by` * During filtering: `relational_query.filter.aggregate.string_agg.order_by` * During sorting:`relational_query.sort.expression.aggregate.string_agg.order_by` * During joining: `relational_query.join.expression.aggregate.string_agg.order_by` * During aggregation: `relational_query.aggregate.expression.aggregate.string_agg.order_by` * During windowing: `relational_query.window.expression.aggregate.string_agg.order_by`
+       */
+      order_by?: Sort[] | null;
+    }
+  | {
+      type: "sum";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "var";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "stddev";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "stddev_pop";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "approx_percentile_cont";
+      expr: RelationalExpression;
+      percentile: number;
+    }
+  | {
+      type: "array_agg";
+      expr: RelationalExpression;
+      /**
+       * Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.aggregate.array_agg.distinct` * During filtering: `relational_query.filter.aggregate.array_agg.distinct` * During sorting:`relational_query.sort.expression.aggregate.array_agg.distinct` * During joining: `relational_query.join.expression.aggregate.array_agg.distinct` * During aggregation: `relational_query.aggregate.expression.aggregate.array_agg.distinct` * During windowing: `relational_query.window.expression.aggregate.array_agg.distinct`
+       */
+      distinct: boolean;
+      /**
+       * Only used when in specific contexts where the appropriate capability is supported: * During projection: `relational_query.project.expression.aggregate.array_agg.order_by` * During filtering: `relational_query.filter.aggregate.array_agg.order_by` * During sorting:`relational_query.sort.expression.aggregate.array_agg.order_by` * During joining: `relational_query.join.expression.aggregate.array_agg.order_by` * During aggregation: `relational_query.aggregate.expression.aggregate.array_agg.order_by` * During windowing: `relational_query.window.expression.aggregate.array_agg.order_by`
+       */
+      order_by?: Sort[] | null;
+    }
+  | {
+      type: "approx_distinct";
+      expr: RelationalExpression;
+    }
+  | {
+      type: "row_number";
+      order_by: Sort[];
+      partition_by: RelationalExpression[];
+    }
+  | {
+      type: "dense_rank";
+      order_by: Sort[];
+      partition_by: RelationalExpression[];
+    }
+  | {
+      type: "n_tile";
+      order_by: Sort[];
+      partition_by: RelationalExpression[];
+      n: number;
+    }
+  | {
+      type: "rank";
+      order_by: Sort[];
+      partition_by: RelationalExpression[];
+    }
+  | {
+      type: "cume_dist";
+      order_by: Sort[];
+      partition_by: RelationalExpression[];
+    }
+  | {
+      type: "percent_rank";
+      order_by: Sort[];
+      partition_by: RelationalExpression[];
+    };
+export type CastType =
+  | {
+      type: "boolean";
+    }
+  | {
+      type: "utf8";
+    }
+  | {
+      type: "int8";
+    }
+  | {
+      type: "int16";
+    }
+  | {
+      type: "int32";
+    }
+  | {
+      type: "int64";
+    }
+  | {
+      type: "uint8";
+    }
+  | {
+      type: "uint16";
+    }
+  | {
+      type: "uint32";
+    }
+  | {
+      type: "uint64";
+    }
+  | {
+      type: "float32";
+    }
+  | {
+      type: "float64";
+    }
+  | {
+      type: "decimal128";
+      scale: number;
+      prec: number;
+    }
+  | {
+      type: "decimal256";
+      scale: number;
+      prec: number;
+    }
+  | {
+      type: "date";
+    }
+  | {
+      type: "time";
+    }
+  | {
+      type: "timestamp";
+    }
+  | {
+      type: "duration";
+    }
+  | {
+      type: "interval";
+    };
+export type DatePartUnit =
+  | "year"
+  | "quarter"
+  | "month"
+  | "week"
+  | "day_of_week"
+  | "day_of_year"
+  | "day"
+  | "hour"
+  | "minute"
+  | "second"
+  | "microsecond"
+  | "millisecond"
+  | "nanosecond"
+  | "epoch";
+export type NullsSort = "nulls_first" | "nulls_last";
+export type JoinType = "left" | "right" | "inner" | "full" | "left_anti" | "left_semi" | "right_anti" | "right_semi";
 
 export interface SchemaRoot {
   capabilities_response: CapabilitiesResponse;
@@ -674,6 +1509,14 @@ export interface SchemaRoot {
   explain_response: ExplainResponse;
   error_response: ErrorResponse;
   validate_response: ValidateResponse;
+  relational_delete_request: RelationalDeleteRequest;
+  relational_delete_response: RelationalDeleteResponse;
+  relational_insert_request: RelationalInsertRequest;
+  relational_insert_response: RelationalInsertResponse;
+  relational_query: RelationalQuery;
+  relational_query_response: RelationalQueryResponse;
+  relational_update_request: RelationalUpdateRequest;
+  relational_update_response: RelationalUpdateResponse;
 }
 export interface CapabilitiesResponse {
   version: string;
@@ -686,6 +1529,14 @@ export interface Capabilities {
   query: QueryCapabilities;
   mutation: MutationCapabilities;
   relationships?: RelationshipCapabilities | null;
+  /**
+   * Does the connector support the relational query API? This feature is experimental and subject to breaking changes within minor versions.
+   */
+  relational_query?: RelationalQueryCapabilities | null;
+  /**
+   * Does the connector support the relational mutation API? This feature is experimental and subject to breaking changes within minor versions.
+   */
+  relational_mutation?: RelationalMutationCapabilities | null;
 }
 export interface QueryCapabilities {
   /**
@@ -827,6 +1678,212 @@ export interface NestedRelationshipCapabilities {
    */
   ordering?: LeafCapability | null;
 }
+/**
+ * Describes which features of the relational query API are supported by the connector. This feature is experimental and subject to breaking changes within minor versions.
+ */
+export interface RelationalQueryCapabilities {
+  project: RelationalProjectionCapabilities;
+  filter?: RelationalExpressionCapabilities | null;
+  sort?: RelationalSortCapabilities | null;
+  join?: RelationalJoinCapabilities | null;
+  aggregate?: RelationalAggregateCapabilities | null;
+  window?: RelationalWindowCapabilities | null;
+  union?: LeafCapability | null;
+  streaming?: LeafCapability | null;
+}
+export interface RelationalProjectionCapabilities {
+  expression: RelationalExpressionCapabilities;
+}
+export interface RelationalExpressionCapabilities {
+  conditional: RelationalConditionalExpressionCapabilities;
+  comparison: RelationalFilterExpressionCapabilities;
+  scalar: RelationalScalarExpressionCapabilities;
+  aggregate: RelationalAggregateExpressionCapabilities;
+  window: RelationalWindowExpressionCapabilities;
+  scalar_types?: RelationalScalarTypeCapabilities | null;
+}
+export interface RelationalConditionalExpressionCapabilities {
+  case?: RelationalCaseCapabilities | null;
+  nullif?: LeafCapability | null;
+}
+export interface RelationalCaseCapabilities {
+  scrutinee?: LeafCapability | null;
+}
+export interface RelationalFilterExpressionCapabilities {
+  between?: LeafCapability | null;
+  contains?: LeafCapability | null;
+  greater_than_eq?: LeafCapability | null;
+  greater_than?: LeafCapability | null;
+  ilike?: LeafCapability | null;
+  in_list?: LeafCapability | null;
+  is_distinct_from?: LeafCapability | null;
+  is_false?: LeafCapability | null;
+  is_nan?: LeafCapability | null;
+  is_null?: LeafCapability | null;
+  is_true?: LeafCapability | null;
+  is_zero?: LeafCapability | null;
+  less_than_eq?: LeafCapability | null;
+  less_than?: LeafCapability | null;
+  like?: LeafCapability | null;
+}
+export interface RelationalScalarExpressionCapabilities {
+  abs?: LeafCapability | null;
+  and?: LeafCapability | null;
+  array_element?: LeafCapability | null;
+  binary_concat?: LeafCapability | null;
+  btrim?: LeafCapability | null;
+  ceil?: LeafCapability | null;
+  character_length?: LeafCapability | null;
+  coalesce?: LeafCapability | null;
+  concat?: LeafCapability | null;
+  cos?: LeafCapability | null;
+  current_date?: LeafCapability | null;
+  current_time?: LeafCapability | null;
+  current_timestamp?: LeafCapability | null;
+  date_part?: DatePartScalarExpressionCapability | null;
+  date_trunc?: LeafCapability | null;
+  divide?: LeafCapability | null;
+  exp?: LeafCapability | null;
+  floor?: LeafCapability | null;
+  get_field?: LeafCapability | null;
+  greatest?: LeafCapability | null;
+  least?: LeafCapability | null;
+  left?: LeafCapability | null;
+  ln?: LeafCapability | null;
+  log?: LeafCapability | null;
+  log10?: LeafCapability | null;
+  log2?: LeafCapability | null;
+  lpad?: LeafCapability | null;
+  ltrim?: LeafCapability | null;
+  minus?: LeafCapability | null;
+  modulo?: LeafCapability | null;
+  multiply?: LeafCapability | null;
+  negate?: LeafCapability | null;
+  not?: LeafCapability | null;
+  nvl?: LeafCapability | null;
+  or?: LeafCapability | null;
+  plus?: LeafCapability | null;
+  power?: LeafCapability | null;
+  random?: LeafCapability | null;
+  replace?: LeafCapability | null;
+  reverse?: LeafCapability | null;
+  right?: LeafCapability | null;
+  round?: LeafCapability | null;
+  rpad?: LeafCapability | null;
+  rtrim?: LeafCapability | null;
+  sqrt?: LeafCapability | null;
+  str_pos?: LeafCapability | null;
+  substr_index?: LeafCapability | null;
+  substr?: LeafCapability | null;
+  tan?: LeafCapability | null;
+  to_date?: LeafCapability | null;
+  to_lower?: LeafCapability | null;
+  to_timestamp?: LeafCapability | null;
+  to_upper?: LeafCapability | null;
+  trunc?: LeafCapability | null;
+  json_contains?: LeafCapability | null;
+  json_get?: LeafCapability | null;
+  json_get_str?: LeafCapability | null;
+  json_get_int?: LeafCapability | null;
+  json_get_float?: LeafCapability | null;
+  json_get_bool?: LeafCapability | null;
+  json_get_json?: LeafCapability | null;
+  json_as_text?: LeafCapability | null;
+  json_length?: LeafCapability | null;
+}
+export interface DatePartScalarExpressionCapability {
+  year?: LeafCapability | null;
+  quarter?: LeafCapability | null;
+  month?: LeafCapability | null;
+  week?: LeafCapability | null;
+  day_of_week?: LeafCapability | null;
+  day_of_year?: LeafCapability | null;
+  day?: LeafCapability | null;
+  hour?: LeafCapability | null;
+  minute?: LeafCapability | null;
+  second?: LeafCapability | null;
+  microsecond?: LeafCapability | null;
+  millisecond?: LeafCapability | null;
+  nanosecond?: LeafCapability | null;
+  epoch?: LeafCapability | null;
+}
+export interface RelationalAggregateExpressionCapabilities {
+  avg?: LeafCapability | null;
+  bool_and?: LeafCapability | null;
+  bool_or?: LeafCapability | null;
+  count?: RelationalAggregateFunctionCapabilities | null;
+  first_value?: LeafCapability | null;
+  last_value?: LeafCapability | null;
+  max?: LeafCapability | null;
+  median?: LeafCapability | null;
+  min?: LeafCapability | null;
+  string_agg?: RelationalOrderedAggregateFunctionCapabilities | null;
+  string_agg_with_separator?: RelationalOrderedAggregateFunctionCapabilities | null;
+  sum?: LeafCapability | null;
+  var?: LeafCapability | null;
+  stddev?: LeafCapability | null;
+  stddev_pop?: LeafCapability | null;
+  approx_percentile_cont?: LeafCapability | null;
+  array_agg?: RelationalOrderedAggregateFunctionCapabilities | null;
+  approx_distinct?: LeafCapability | null;
+}
+export interface RelationalAggregateFunctionCapabilities {
+  distinct?: LeafCapability | null;
+}
+export interface RelationalOrderedAggregateFunctionCapabilities {
+  distinct?: LeafCapability | null;
+  order_by?: LeafCapability | null;
+}
+export interface RelationalWindowExpressionCapabilities {
+  row_number?: LeafCapability | null;
+  dense_rank?: LeafCapability | null;
+  ntile?: LeafCapability | null;
+  rank?: LeafCapability | null;
+  cume_dist?: LeafCapability | null;
+  percent_rank?: LeafCapability | null;
+}
+export interface RelationalScalarTypeCapabilities {
+  /**
+   * Does the connector support the INTERVAL scalar type? Both interval literals and casts to the INTERVAL type are implied by this capability.
+   */
+  interval?: LeafCapability | null;
+  /**
+   * Does the connector support `from_type` in cast?
+   */
+  from_type?: LeafCapability | null;
+}
+export interface RelationalSortCapabilities {
+  expression: RelationalExpressionCapabilities;
+}
+export interface RelationalJoinCapabilities {
+  expression: RelationalExpressionCapabilities;
+  join_types: RelationalJoinTypeCapabilities;
+}
+export interface RelationalJoinTypeCapabilities {
+  left?: LeafCapability | null;
+  right?: LeafCapability | null;
+  inner?: LeafCapability | null;
+  full?: LeafCapability | null;
+  left_semi?: LeafCapability | null;
+  left_anti?: LeafCapability | null;
+  right_semi?: LeafCapability | null;
+  right_anti?: LeafCapability | null;
+}
+export interface RelationalAggregateCapabilities {
+  expression: RelationalExpressionCapabilities;
+  group_by?: LeafCapability | null;
+}
+export interface RelationalWindowCapabilities {
+  expression: RelationalExpressionCapabilities;
+}
+/**
+ * Describes which features of the relational mutation API are supported by the connector. This feature is experimental and subject to breaking changes within minor versions.
+ */
+export interface RelationalMutationCapabilities {
+  insert?: LeafCapability | null;
+  update?: LeafCapability | null;
+  delete?: LeafCapability | null;
+}
 export interface SchemaResponse {
   /**
    * A list of scalar types which will be used as the types of collection columns
@@ -856,6 +1913,10 @@ export interface SchemaResponse {
    * Schema data which is relevant to features enabled by capabilities
    */
   capabilities?: CapabilitySchemaInfo | null;
+  /**
+   * Request level arguments which are required for queries and mutations
+   */
+  request_arguments?: RequestLevelArguments | null;
 }
 /**
  * The definition of a scalar type, i.e. types that can be used as the types of columns.
@@ -973,12 +2034,30 @@ export interface CollectionInfo {
   uniqueness_constraints: {
     [k: string]: UniquenessConstraint;
   };
+  /**
+   * Information about relational mutation capabilities for this collection
+   */
+  relational_mutations?: RelationalMutationInfo | null;
 }
 export interface UniquenessConstraint {
   /**
    * A list of columns which this constraint requires to be unique
    */
   unique_columns: string[];
+}
+export interface RelationalMutationInfo {
+  /**
+   * Whether inserts are supported for this collection
+   */
+  insertable: boolean;
+  /**
+   * Whether updates are supported for this collection
+   */
+  updatable: boolean;
+  /**
+   * Whether deletes are supported for this collection
+   */
+  deletable: boolean;
 }
 export interface FunctionInfo {
   /**
@@ -1038,6 +2117,26 @@ export interface AggregateCapabilitiesSchemaInfo {
    */
   count_scalar_type: string;
 }
+export interface RequestLevelArguments {
+  /**
+   * Any arguments that all Query requests require
+   */
+  query_arguments: {
+    [k: string]: ArgumentInfo;
+  };
+  /**
+   * Any arguments that all Mutation requests require
+   */
+  mutation_arguments: {
+    [k: string]: ArgumentInfo;
+  };
+  /**
+   * Any arguments that all Relational Query requests require
+   */
+  relational_query_arguments: {
+    [k: string]: ArgumentInfo;
+  };
+}
 /**
  * This is the request body of the query POST endpoint
  */
@@ -1070,6 +2169,12 @@ export interface QueryRequest {
         [k: string]: unknown;
       }[]
     | null;
+  /**
+   * Values to be provided to request-level arguments.
+   */
+  request_arguments?: {
+    [k: string]: unknown;
+  } | null;
 }
 export interface Query {
   /**
@@ -1253,6 +2358,12 @@ export interface MutationRequest {
   collection_relationships: {
     [k: string]: Relationship;
   };
+  /**
+   * Values to be provided to request-level arguments.
+   */
+  request_arguments?: {
+    [k: string]: unknown;
+  } | null;
 }
 export interface MutationResponse {
   /**
@@ -1284,4 +2395,99 @@ export interface ValidateResponse {
   schema: SchemaResponse;
   capabilities: CapabilitiesResponse;
   resolved_configuration: string;
+}
+export interface RelationalDeleteRequest {
+  /**
+   * The name of the collection to delete from
+   */
+  collection: string;
+  /**
+   * Values to be provided to any collection arguments
+   */
+  arguments: {
+    [k: string]: Argument;
+  };
+  /**
+   * The relation that identifies which rows to delete
+   */
+  relation: Relation;
+}
+export interface CaseWhen {
+  when: RelationalExpression;
+  then: RelationalExpression;
+}
+export interface Sort {
+  expr: RelationalExpression;
+  direction: OrderDirection;
+  nulls_sort: NullsSort;
+}
+export interface JoinOn {
+  left: RelationalExpression;
+  right: RelationalExpression;
+}
+export interface RelationalDeleteResponse {
+  /**
+   * The number of rows that were deleted
+   */
+  affected_rows: number;
+}
+export interface RelationalInsertRequest {
+  /**
+   * The name of the collection to insert into
+   */
+  collection: string;
+  /**
+   * Values to be provided to any collection arguments
+   */
+  arguments: {
+    [k: string]: Argument;
+  };
+  /**
+   * The columns to insert values for
+   */
+  columns: string[];
+  /**
+   * The rows to insert, each row containing values for the specified columns
+   */
+  rows: unknown[][];
+}
+export interface RelationalInsertResponse {
+  /**
+   * The number of rows that were inserted
+   */
+  affected_rows: number;
+}
+export interface RelationalQuery {
+  root_relation: Relation;
+  /**
+   * Values to be provided to request-level arguments.
+   */
+  request_arguments?: {
+    [k: string]: unknown;
+  } | null;
+}
+export interface RelationalQueryResponse {
+  rows: unknown[][];
+}
+export interface RelationalUpdateRequest {
+  /**
+   * The name of the collection to update
+   */
+  collection: string;
+  /**
+   * Values to be provided to any collection arguments
+   */
+  arguments: {
+    [k: string]: Argument;
+  };
+  /**
+   * The relation that identifies which rows to update
+   */
+  relation: Relation;
+}
+export interface RelationalUpdateResponse {
+  /**
+   * The number of rows that were updated
+   */
+  affected_rows: number;
 }

--- a/src/schema/version.generated.ts
+++ b/src/schema/version.generated.ts
@@ -1,2 +1,2 @@
-export const VERSION = "0.2.0";
+export const VERSION = "0.2.12";
 export const VERSION_HEADER_NAME="X-Hasura-NDC-Version"

--- a/typegen/Cargo.toml
+++ b/typegen/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.2.0" }
-schemars = "^0.8"
-serde = "^1.0"
-serde_json = "^1.0"
-serde_derive = "^1.0"
+ndc-models = { git = "http://github.com/hasura/ndc-spec.git", tag = "v0.2.12" }
+schemars = "0.8"
+serde = "1"
+serde_json = "1"
+serde_derive = "1"

--- a/typegen/regenerate-schema.sh
+++ b/typegen/regenerate-schema.sh
@@ -5,7 +5,7 @@ set -eu -o pipefail
 cargo run -- ./src/schema
 
 # Generate TypeScript types from JSON schema
-json2ts -i ./src/schema/schema.generated.json -o ./src/schema/schema.generated.ts --no-additionalProperties
+npx --package=json-schema-to-typescript json2ts -i ./src/schema/schema.generated.json -o ./src/schema/schema.generated.ts --no-additionalProperties
 echo './src/schema/schema.generated.ts generated'
 
 # Unfortunately we have a manual patch of the generated types in place

--- a/typegen/src/main.rs
+++ b/typegen/src/main.rs
@@ -1,6 +1,9 @@
 use ndc_models::{
     CapabilitiesResponse, ErrorResponse, ExplainResponse, MutationRequest, MutationResponse,
-    QueryRequest, QueryResponse, SchemaResponse, VERSION, VERSION_HEADER_NAME,
+    QueryRequest, QueryResponse, RelationalDeleteRequest, RelationalDeleteResponse,
+    RelationalInsertRequest, RelationalInsertResponse, RelationalQuery, RelationalQueryResponse,
+    RelationalUpdateRequest, RelationalUpdateResponse, SchemaResponse, VERSION,
+    VERSION_HEADER_NAME,
 };
 use schemars::{schema_for, JsonSchema};
 use serde_derive::{Deserialize, Serialize};
@@ -18,6 +21,14 @@ struct SchemaRoot {
     explain_response: ExplainResponse,
     error_response: ErrorResponse,
     validate_response: ValidateResponse,
+    relational_delete_request: RelationalDeleteRequest,
+    relational_delete_response: RelationalDeleteResponse,
+    relational_insert_request: RelationalInsertRequest,
+    relational_insert_response: RelationalInsertResponse,
+    relational_query: RelationalQuery,
+    relational_query_response: RelationalQueryResponse,
+    relational_update_request: RelationalUpdateRequest,
+    relational_update_response: RelationalUpdateResponse,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]


### PR DESCRIPTION
This pull request updates the project to use NDC spec version 0.2.12 and adds support for relational request/response types. The changes ensure compatibility with the latest NDC models and improve the schema generation process.

**Version and Dependency Updates:**

* Updated the `VERSION` constant in `src/schema/version.generated.ts` and the `ndc-models` dependency in `typegen/Cargo.toml` to use NDC spec version 0.2.12. [[1]](diffhunk://#diff-62c19193e8cc16a71918af267be60a6b936297c90fce6f5241545b246296b1cdL1-R1) [[2]](diffhunk://#diff-2610635e36956bd11d4fa6cf47082bc1e2b7b6a81081c188d84cce222df382afL9-R13)

**Schema and Type Generation Improvements:**

* Changed the schema generation script in `typegen/regenerate-schema.sh` to use `json-schema-to-typescript` via `npx` for generating TypeScript types, improving reproducibility and avoiding global dependencies.

**Relational API Support:**

* Added new relational request and response types (`RelationalDeleteRequest`, `RelationalDeleteResponse`, `RelationalInsertRequest`, `RelationalInsertResponse`, `RelationalQuery`, `RelationalQueryResponse`, `RelationalUpdateRequest`, `RelationalUpdateResponse`) to the imports and the `SchemaRoot` struct in `typegen/src/main.rs`, enabling support for relational APIs in schema generation. [[1]](diffhunk://#diff-a8e4fecd0a393eb2ef5eb5829d1c02014057ee450396c19ee827cd0d38218342L3-R6) [[2]](diffhunk://#diff-a8e4fecd0a393eb2ef5eb5829d1c02014057ee450396c19ee827cd0d38218342R24-R31)