### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build_test_publish.yaml
+++ b/.github/workflows/build_test_publish.yaml
@@ -12,8 +12,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version-file: .nvmrc
           registry-url: 'https://registry.npmjs.org'
@@ -26,8 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version-file: .nvmrc
           registry-url: 'https://registry.npmjs.org'
@@ -57,13 +57,13 @@ jobs:
           echo "tagged_version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
         shell: bash
 
-      - uses: mindsers/changelog-reader-action@v2
+      - uses: mindsers/changelog-reader-action@97a0b06549019bb99a571f1664272db18031acff # v2
         id: changelog-reader
         with:
           version: ${{ steps.get-version.outputs.tagged_version }}
           path: ./CHANGELOG.md
 
-      - uses: softprops/action-gh-release@v1
+      - uses: softprops/action-gh-release@b21b43df682dab285bf5146c1955e7f3560805f8 # v1
         with:
           draft: false
           tag_name: v${{ steps.get-version.outputs.tagged_version }}


### PR DESCRIPTION
## Summary
- Pin all public GitHub Action references to their immutable commit SHAs
- Original version tags preserved as inline comments for maintainability
- Prevents supply chain attacks via mutable tag references

## Test plan
- [ ] Verify CI workflows still trigger and run correctly
- [ ] Spot-check a few pinned SHAs match their expected tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)